### PR TITLE
produce a moment.js 2.9.0 build

### DIFF
--- a/moment/README.md
+++ b/moment/README.md
@@ -2,7 +2,7 @@
 
 [](dependency)
 ```clojure
-[cljsjs/moment "2.6.0-3"] ;; latest release
+[cljsjs/moment "2.9.0-0"] ;; latest release
 ```
 [](/dependency)
 

--- a/moment/build.boot
+++ b/moment/build.boot
@@ -6,7 +6,7 @@
 (require '[adzerk.bootlaces :refer :all]
          '[cljsjs.boot-cljsjs.packaging :refer :all])
 
-(def +version+ "2.6.0-3")
+(def +version+ "2.9.0-0")
 (bootlaces! +version+)
 
 (task-options!
@@ -20,8 +20,8 @@
 
 (deftask package []
   (comp
-    (download :url "https://github.com/moment/moment/archive/2.6.0.zip"
-              :checksum "0f9b226ff824066a2040056a4abfa0f6"
+    (download :url "https://github.com/moment/moment/archive/2.9.0.zip"
+              :checksum "ee7c9584c71459c2c701645a7164a890"
               :unzip true)
     (sift :move {#"^moment-.*/moment.js"         "cljsjs/development/moment.inc.js"
                  #"^moment-.*/min/moment.min.js" "cljsjs/production/moment.min.inc.js"})

--- a/moment/resources/cljsjs/common/moment.ext.js
+++ b/moment/resources/cljsjs/common/moment.ext.js
@@ -443,3 +443,8 @@ Moment.prototype.min = function() {};
  * @since 2.1.0
  */
 Moment.prototype.max = function() {};
+
+/**
+ * @since 2.8.1
+ */
+Moment.prototype.locale = function() {};


### PR DESCRIPTION
This is working for me within an adapted version of @martinklepsch 's testbed. I've updated the externs file to include moment.locale(...) introduced in 2.8.1.