### PR TITLE
Package leaflet.js with externs

### DIFF
--- a/leaflet/README.md
+++ b/leaflet/README.md
@@ -1,0 +1,18 @@
+# cljsjs/leaflet
+
+[](dependency)
+```clojure
+[cljsjs/leaflet "0.7.3"] ;; latest release
+```
+[](/dependency)
+
+This jar comes with `deps.cljs` as used by the [Foreign Libs][flibs] feature
+of the Clojurescript compiler. After adding the above dependency to your project
+to can require the packaged library like so:
+
+```clojure
+(ns application.core
+  (:require cljsjs.leaflet))
+```
+
+[flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies

--- a/leaflet/build.boot
+++ b/leaflet/build.boot
@@ -1,0 +1,30 @@
+(set-env!
+ :resource-paths #{"resources"}
+ :dependencies '[[adzerk/bootlaces   "0.1.9" :scope "test"]
+                 [cljsjs/boot-cljsjs "0.4.6" :scope "test"]])
+
+(require '[adzerk.bootlaces :refer :all]
+         '[cljsjs.boot-cljsjs.packaging :refer :all])
+
+(def +version+ "0.7.3")
+(bootlaces! +version+)
+
+(task-options!
+ pom  {:project     'cljsjs/leaflet
+       :version     +version+
+       :description "JavaScript library for mobile-friendly interactive maps"
+       :url         "http://leaflet.com/"
+       :scm         {:url "https://github.com/cljsjs/packages"}
+       :license     {"Leaflet License" "https://github.com/Leaflet/Leaflet/blob/master/LICENSE"}})
+
+(deftask package []
+  (comp
+   (download :url "http://leaflet-cdn.s3.amazonaws.com/build/leaflet-0.7.3.zip"
+             :checksum "08A7F76F4B91DFACB07FEC70A8A1331A"
+             :unzip true)
+   (sift :move {#"leaflet\.js" "cljsjs/production/leaflet.inc.js"
+                #"leaflet-src\.js" "cljsjs/development/leaflet-src.inc.js"
+                #"leaflet\.css" "cljsjs/common/leaflet.inc.css"
+                #"images" "cljsjs/common/images"})
+   (sift :include #{#"^cljsjs"})
+   (deps-cljs :name "cljsjs.leaflet")))

--- a/leaflet/resources/cljsjs/common/leaflet.ext.js
+++ b/leaflet/resources/cljsjs/common/leaflet.ext.js
@@ -1,0 +1,5 @@
+/**
+ * @externs
+ * Simple externs for Leaflet's `L` object
+ */
+var L = {};


### PR DESCRIPTION
I am unsure how to test this, but it looks good from what I can tell - the `package` task properly outputs to the target. If someone gives me some brief instructions on how to test the packaging then I will do so before merging. (The [testbed repo](https://github.com/cljsjs/testbed) is pretty barebones, but I could make a pull request over there to add a Leaflet map.)