### PR TITLE
Update README.md

### DIFF
--- a/fixed-data-table/README.md
+++ b/fixed-data-table/README.md
@@ -2,7 +2,7 @@
 
 [](dependency)
 ```clojure
-[cljsjs/fixed-data-table "0.1.2-1"] ;; latest release
+[cljsjs/fixed-data-table "0.1.2-2"] ;; latest release
 ```
 [](/dependency)
 


### PR DESCRIPTION
It seems that the -1 version in Clojars is still broken, and -2 is the correct one.