### PR TITLE
[heap] Added 1.0.0

### DIFF
--- a/heap/README.md
+++ b/heap/README.md
@@ -1,0 +1,14 @@
+# cljsjs/heap
+[](dependency)
+```clojure
+[cljsjs/heap "0.0.1-0"] ;; latest release
+```
+[](/dependency)
+
+This jar comes with `deps.cljs` as used by the [Foreign Libs][flibs] feature
+of the Clojurescript compiler.
+
+The jar only provides an extern file required for advanced compilation.
+The Heap js API will still need to be provided through some other mechanism.
+[flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
+

--- a/heap/build.boot
+++ b/heap/build.boot
@@ -1,0 +1,18 @@
+(set-env!
+  :resource-paths #{"resources"}
+  :dependencies '[[adzerk/bootlaces   "0.1.9" :scope "test"]
+                  [cljsjs/boot-cljsjs "0.4.7" :scope "test"]])
+
+(require '[adzerk.bootlaces :refer :all]
+         '[cljsjs.boot-cljsjs.packaging :refer :all])
+
+(def +version+ "0.0.1-0")
+
+(task-options!
+ pom  {:project     'cljsjs/heap
+       :version     +version+
+       :description "Heap  js ext lib"
+       :url         "https://heapanalytics.com/docs/custom-api"
+       :scm         {:url "https://github.com/cljsjs/packages"}
+       :license     {"Heap  ToS" "https://heapanalytics.com/terms"}})
+

--- a/heap/resources/cljsjs/common/heap.ext.js
+++ b/heap/resources/cljsjs/common/heap.ext.js
@@ -1,0 +1,34 @@
+/**
+ * @fileoverview Externs for Heap.js
+ *
+ * @see https://heapanalytics.com/docs/custom-api
+ * @externs
+ */
+
+/** @const */
+var heap = {};
+
+heap.userid;
+
+/**
+ * @param {Object} o
+ */
+heap.identify = function(o) { };
+
+/**
+ * @param {string} s
+ * @param {Object} o
+ */
+heap.track = function(s,o) {};
+
+/**
+ * @param {Object} o
+ */
+heap.setEventProperties = function(o) { };
+
+/**
+ * @param {string} s
+ */
+heap.unsetEventProperties = function(s) { };
+
+heap.clearEventProperties = function() { };

--- a/heap/resources/deps.cljs
+++ b/heap/resources/deps.cljs
@@ -1,0 +1,1 @@
+{:externs  ["cljsjs/common/heap.ext.js"]}


### PR DESCRIPTION
Heap JS currently doesn't define a version number. I discussed with heap guys and then will consider it in the future.
For now I just used `1.0.0`. As you can't choose your JS file but have to use whatever their latest is I don't think it is a problem.