### PR TITLE
Fix rampant grammar mistake

### DIFF
--- a/c3/README.md
+++ b/c3/README.md
@@ -8,7 +8,7 @@
 
 This jar comes with `deps.cljs` as used by the [Foreign Libs][flibs] feature
 of the Clojurescript compiler. After adding the above dependency to your project
-to can require the packaged library like so:
+you can require the packaged library like so:
 
 ```clojure
 (ns application.core
@@ -16,4 +16,3 @@ to can require the packaged library like so:
 ```
 
 [flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
-

--- a/chance/README.md
+++ b/chance/README.md
@@ -8,7 +8,7 @@
 
 This jar comes with `deps.cljs` as used by the [Foreign Libs][flibs] feature
 of the Clojurescript compiler. After adding the above dependency to your project
-to can require the packaged library like so:
+you can require the packaged library like so:
 
 ```clojure
 (ns application.core
@@ -16,4 +16,3 @@ to can require the packaged library like so:
 ```
 
 [flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
-

--- a/css-layout/README.md
+++ b/css-layout/README.md
@@ -8,7 +8,7 @@
 
 This jar comes with `deps.cljs` as used by the [Foreign Libs][flibs] feature
 of the Clojurescript compiler. After adding the above dependency to your project
-to can require the packaged library like so:
+you can require the packaged library like so:
 
 ```clojure
 (ns application.core
@@ -16,4 +16,3 @@ to can require the packaged library like so:
 ```
 
 [flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
-

--- a/csv/README.md
+++ b/csv/README.md
@@ -8,7 +8,7 @@
 
 This jar comes with `deps.cljs` as used by the [Foreign Libs][flibs] feature
 of the Clojurescript compiler. After adding the above dependency to your project
-to can require the packaged library like so:
+you can require the packaged library like so:
 
 ```clojure
 (ns application.core
@@ -16,4 +16,3 @@ to can require the packaged library like so:
 ```
 
 [flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
-

--- a/d3/README.md
+++ b/d3/README.md
@@ -8,7 +8,7 @@
 
 This jar comes with `deps.cljs` as used by the [Foreign Libs][flibs] feature
 of the Clojurescript compiler. After adding the above dependency to your project
-to can require the packaged library like so:
+you can require the packaged library like so:
 
 ```clojure
 (ns application.core
@@ -18,4 +18,3 @@ to can require the packaged library like so:
 Uses externs provided by `federico-b/d3-externs`, many thanks!
 
 [flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
-

--- a/dimple/README.md
+++ b/dimple/README.md
@@ -8,7 +8,7 @@
 
 This jar comes with `deps.cljs` as used by the [Foreign Libs][flibs] feature
 of the Clojurescript compiler. After adding the above dependency to your project
-to can require the packaged library like so:
+you can require the packaged library like so:
 
 ```clojure
 (ns application.core
@@ -16,6 +16,3 @@ to can require the packaged library like so:
 ```
 
 No proper externs yet - just figuring things out at the moment....
-
-
-

--- a/document-register-element/README.md
+++ b/document-register-element/README.md
@@ -8,7 +8,7 @@
 
 This jar comes with `deps.cljs` as used by the [Foreign Libs][flibs] feature
 of the Clojurescript compiler. After adding the above dependency to your project
-to can require the packaged library like so:
+you can require the packaged library like so:
 
 `document-register-element` polyfills the Custom Elements specification. Related methods are already defined in externs packaged by the closure compiler thus this module is extern free.
 
@@ -18,4 +18,3 @@ to can require the packaged library like so:
 ```
 
 [flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
-

--- a/firebase/README.md
+++ b/firebase/README.md
@@ -8,7 +8,7 @@
 
 This jar comes with `deps.cljs` as used by the [Foreign Libs][flibs] feature
 of the Clojurescript compiler. After adding the above dependency to your project
-to can require the packaged library like so:
+you can require the packaged library like so:
 
 ```clojure
 (ns application.core
@@ -16,4 +16,3 @@ to can require the packaged library like so:
 ```
 
 [flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
-

--- a/fixed-data-table/README.md
+++ b/fixed-data-table/README.md
@@ -8,7 +8,7 @@
 
 This jar comes with `deps.cljs` as used by the [Foreign Libs][flibs] feature
 of the Clojurescript compiler. After adding the above dependency to your project
-to can require the packaged library like so:
+you can require the packaged library like so:
 
 ```clojure
 (ns application.core

--- a/hammer/README.md
+++ b/hammer/README.md
@@ -8,7 +8,7 @@
 
 This jar comes with `deps.cljs` as used by the [Foreign Libs][flibs] feature
 of the Clojurescript compiler. After adding the above dependency to your project
-to can require the packaged library like so:
+you can require the packaged library like so:
 
 ```clojure
 (ns application.core
@@ -16,4 +16,3 @@ to can require the packaged library like so:
 ```
 
 [flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
-

--- a/hashids/README.md
+++ b/hashids/README.md
@@ -8,7 +8,7 @@
 
 This jar comes with `deps.cljs` as used by the [Foreign Libs][flibs] feature
 of the Clojurescript compiler. After adding the above dependency to your project
-to can require the packaged library like so:
+you can require the packaged library like so:
 
 ```clojure
 (ns application.core
@@ -16,4 +16,3 @@ to can require the packaged library like so:
 ```
 
 [flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
-

--- a/jquery-daterange-picker/README.md
+++ b/jquery-daterange-picker/README.md
@@ -8,7 +8,7 @@
 
 This jar comes with `deps.cljs` as used by the [Foreign Libs][flibs] feature
 of the Clojurescript compiler. After adding the above dependency to your project
-to can require the packaged library like so:
+you can require the packaged library like so:
 
 ```clojure
 (ns application.core
@@ -16,4 +16,3 @@ to can require the packaged library like so:
 ```
 
 [flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
-

--- a/jquery-ui/README.md
+++ b/jquery-ui/README.md
@@ -8,7 +8,7 @@
 
 This jar comes with `deps.cljs` as used by the [Foreign Libs][flibs] feature
 of the Clojurescript compiler. After adding the above dependency to your project
-to can require the packaged library like so:
+you can require the packaged library like so:
 
 ```clojure
 (ns application.core
@@ -16,4 +16,3 @@ to can require the packaged library like so:
 ```
 
 [flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
-

--- a/jquery/README.md
+++ b/jquery/README.md
@@ -8,7 +8,7 @@
 
 This jar comes with `deps.cljs` as used by the [Foreign Libs][flibs] feature
 of the Clojurescript compiler. After adding the above dependency to your project
-to can require the packaged library like so:
+you can require the packaged library like so:
 
 ```clojure
 (ns application.core
@@ -16,4 +16,3 @@ to can require the packaged library like so:
 ```
 
 [flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
-

--- a/jsdiff/README.md
+++ b/jsdiff/README.md
@@ -8,7 +8,7 @@
 
 This jar comes with `deps.cljs` as used by the [Foreign Libs][flibs] feature
 of the Clojurescript compiler. After adding the above dependency to your project
-to can require the packaged library like so:
+you can require the packaged library like so:
 
 ```clojure
 (ns application.core
@@ -16,4 +16,3 @@ to can require the packaged library like so:
 ```
 
 [flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
-

--- a/leaflet/README.md
+++ b/leaflet/README.md
@@ -8,7 +8,7 @@
 
 This jar comes with `deps.cljs` as used by the [Foreign Libs][flibs] feature
 of the Clojurescript compiler. After adding the above dependency to your project
-to can require the packaged library like so:
+you can require the packaged library like so:
 
 ```clojure
 (ns application.core
@@ -16,4 +16,3 @@ to can require the packaged library like so:
 ```
 
 [flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
-

--- a/moment/README.md
+++ b/moment/README.md
@@ -8,7 +8,7 @@
 
 This jar comes with `deps.cljs` as used by the [Foreign Libs][flibs] feature
 of the Clojurescript compiler. After adding the above dependency to your project
-to can require the packaged library like so:
+you can require the packaged library like so:
 
 ```clojure
 (ns application.core
@@ -28,4 +28,3 @@ You should be able to set Moment to use locales if you first require them.
 ```
 
 [flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
-

--- a/mustache/README.md
+++ b/mustache/README.md
@@ -8,7 +8,7 @@
 
 This jar comes with `deps.cljs` as used by the [Foreign Libs][flibs] feature
 of the Clojurescript compiler. After adding the above dependency to your project
-to can require the packaged library like so:
+you can require the packaged library like so:
 
 ```clojure
 (ns application.core
@@ -16,4 +16,3 @@ to can require the packaged library like so:
 ```
 
 [flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
-

--- a/object-assign-shim/README.md
+++ b/object-assign-shim/README.md
@@ -8,7 +8,7 @@
 
 This jar comes with `deps.cljs` as used by the [Foreign Libs][flibs] feature
 of the Clojurescript compiler. After adding the above dependency to your project
-to can require the packaged library like so:
+you can require the packaged library like so:
 
 ```clojure
 (ns application.core

--- a/pikaday/README.md
+++ b/pikaday/README.md
@@ -8,7 +8,7 @@
 
 This jar comes with `deps.cljs` as used by the [Foreign Libs][flibs] feature
 of the Clojurescript compiler. After adding the above dependency to your project
-to can require the packaged library like so:
+you can require the packaged library like so:
 
 ```clojure
 (ns application.core
@@ -23,4 +23,3 @@ or if you want to use pikadays optional Moment.js integration:
 ```
 
 [flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
-

--- a/pouchdb/README.md
+++ b/pouchdb/README.md
@@ -8,7 +8,7 @@
 
 This jar comes with `deps.cljs` as used by the [Foreign Libs][flibs] feature
 of the Clojurescript compiler. After adding the above dependency to your project
-to can require the packaged library like so:
+you can require the packaged library like so:
 
 ```clojure
 (ns application.core
@@ -16,4 +16,3 @@ to can require the packaged library like so:
 ```
 
 [flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
-

--- a/react-router/README.md
+++ b/react-router/README.md
@@ -8,7 +8,7 @@
 
 This jar comes with `deps.cljs` as used by the [Foreign Libs][flibs] feature
 of the Clojurescript compiler. After adding the above dependency to your project
-to can require the packaged library like so:
+you can require the packaged library like so:
 
 ```clojure
 (ns application.core

--- a/react/README.md
+++ b/react/README.md
@@ -6,7 +6,7 @@
 
 This jar comes with `deps.cljs` as used by the [Foreign Libs][flibs] feature
 of the Clojurescript compiler. After adding the above dependency to your project
-to can require the packaged library like so:
+you can require the packaged library like so:
 
 ```clojure
 (ns application.core

--- a/three/README.md
+++ b/three/README.md
@@ -8,7 +8,7 @@
 
 This jar comes with `deps.cljs` as used by the [Foreign Libs][flibs] feature
 of the Clojurescript compiler. After adding the above dependency to your project
-to can require the packaged library like so:
+you can require the packaged library like so:
 
 ```clojure
 (ns application.core
@@ -16,4 +16,3 @@ to can require the packaged library like so:
 ```
 
 [flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
-

--- a/topojson/README.md
+++ b/topojson/README.md
@@ -8,7 +8,7 @@
 
 This jar comes with `deps.cljs` as used by the [Foreign Libs][flibs] feature
 of the Clojurescript compiler. After adding the above dependency to your project
-to can require the packaged library like so:
+you can require the packaged library like so:
 
 ```clojure
 (ns application.core
@@ -17,4 +17,3 @@ to can require the packaged library like so:
 ```
 
 [flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
-

--- a/waypoints/README.md
+++ b/waypoints/README.md
@@ -8,7 +8,7 @@
 
 This jar comes with `deps.cljs` as used by the [Foreign Libs][flibs]
 feature of the Clojurescript compiler. After adding the above
-dependency to your project to can require the packaged library like
+dependency to your project you can require the packaged library like
 so:
 
 ```clojure


### PR DESCRIPTION
I suppose because of all the copy-paste for creating packages, a substantial number of packages had a small typo/mistake in their README's.