### PR TITLE
[showdown] Fix externs

### DIFF
--- a/showdown/README.md
+++ b/showdown/README.md
@@ -2,7 +2,7 @@
 
 [](dependency)
 ```clojure
-[cljsjs/showdown "0.4.0-0"] ;; latest release
+[cljsjs/showdown "0.4.0-1"] ;; latest release
 ```
 [](/dependency)
 

--- a/showdown/build.boot
+++ b/showdown/build.boot
@@ -6,7 +6,7 @@
 (require '[adzerk.bootlaces :refer :all]
          '[cljsjs.boot-cljsjs.packaging :refer :all])
 
-(def +version+ "0.4.0-0")
+(def +version+ "0.4.0-1")
 (bootlaces! +version+)
 
 (task-options!

--- a/showdown/resources/cljsjs/showdown/common/showdown.ext.js
+++ b/showdown/resources/cljsjs/showdown/common/showdown.ext.js
@@ -3,3 +3,5 @@ var Showdown = {
     "forEach": function () {},
     "converter": function () {}
 };
+
+Showdown.converter.prototype.makeHtml = function () {};


### PR DESCRIPTION
Ensure Showdown.converter.prototype.makeHtml doesn't get swallowed by advanced compilation.