### PR TITLE
Add peg 0.8.0 cljsjs package

### DIFF
--- a/peg/build.boot
+++ b/peg/build.boot
@@ -1,0 +1,29 @@
+(set-env!
+  :resource-paths #{"resources"}
+  :dependencies '[[adzerk/bootlaces   "0.1.10" :scope "test"]
+                  [cljsjs/boot-cljsjs "0.4.6"  :scope "test"]])
+
+(require '[adzerk.bootlaces :refer :all]
+         '[cljsjs.boot-cljsjs.packaging :refer :all])
+
+(def +version+ "0.8.0")
+(bootlaces! +version+)
+
+(task-options!
+ pom  {:project     'cljsjs/peg
+       :version     +version+
+       :description "PEG.js: Parser generator for JavaScript"
+       :url         "http://pegjs.org/"
+       :scm         {:url "https://github.com/cljsjs/packages"}
+       :license     {"BSD" "http://opensource.org/licenses/BSD-3-Clause"}})
+
+(deftask package []
+  (comp
+    (download :url "https://github.com/pegjs/pegjs/releases/download/v0.8.0/peg-0.8.0.js"
+              :checksum "992f208961e69128046411f881776c5f")
+    (download :url "https://github.com/pegjs/pegjs/releases/download/v0.8.0/peg-0.8.0.min.js"
+              :checksum "abd4f4b562bcc818b5ef842c756f386e")
+    (sift :move {#"^peg-0\.8\.0\.js"      "cljsjs/peg/development/peg.inc.js"
+                 #"^peg-0\.8\.0\.min\.js" "cljsjs/peg/production/peg.min.inc.js"})
+    (sift :include #{#"^cljsjs"})
+    (deps-cljs :name "cljsjs.peg")))

--- a/peg/resources/cljsjs/peg/common/peg.ext.js
+++ b/peg/resources/cljsjs/peg/common/peg.ext.js
@@ -1,0 +1,11 @@
+/**
+ * @fileoverview Closure Compiler externs for peg.js 0.8.0
+ * @see http://pegjs.org
+ * @externs
+ */
+
+/* Bare minimum */
+
+var PEG = {};
+
+PEG.buildParser = function(grammar) {};

--- a/peg/resources/cljsjs/peg/common/peg.ext.js
+++ b/peg/resources/cljsjs/peg/common/peg.ext.js
@@ -8,4 +8,4 @@
 
 var PEG = {};
 
-PEG.buildParser = function(grammar) {};
+PEG.buildParser = function(grammar) { return { parse: function(input){} }; };


### PR DESCRIPTION
Tested it locally with
```cljs
(ns foobar.core
  (:require
   ...
   [cljsjs.peg]))
...
(def grammar " ... big long PEG.js grammar ")
(def parser (.buildParser js/PEG grammar))
(defn parse-string [str] (.parse parser str))
```
and seems to work ok.

I'm fairly new to clojure[script] so hopefully I didn't do anything too unidiomatic.