### PR TITLE
[jquery-ui] Update to 1.11.4, [jquery] to 2.1.1

### DIFF
--- a/jquery-ui/README.md
+++ b/jquery-ui/README.md
@@ -2,7 +2,7 @@
 
 [](dependency)
 ```clojure
-[cljsjs/jquery-ui "1.11.3-1"] ;; latest release
+[cljsjs/jquery-ui "1.11.4-0"] ;; latest release
 ```
 [](/dependency)
 

--- a/jquery-ui/build.boot
+++ b/jquery-ui/build.boot
@@ -34,4 +34,4 @@
                  })
     (sift :include #{#"^cljsjs"})
     (deps-cljs :name "cljsjs.jquery-ui"
-               :requires ["cljsjs.jquery" "cljsjs.jquery-ui"])))
+               :requires ["cljsjs.jquery"])))

--- a/jquery-ui/build.boot
+++ b/jquery-ui/build.boot
@@ -2,12 +2,12 @@
   :resource-paths #{"resources"}
   :dependencies '[[adzerk/bootlaces   "0.1.9" :scope "test"]
                   [cljsjs/boot-cljsjs "0.4.6" :scope "test"]
-                  [cljsjs/jquery "1.9.0-0"]])
+                  [cljsjs/jquery "2.1.1-0"]])
 
 (require '[adzerk.bootlaces :refer :all]
          '[cljsjs.boot-cljsjs.packaging :refer :all])
 
-(def +version+ "1.11.3-1")
+(def +version+ "1.11.4-0")
 
 (task-options!
  pom  {:project     'cljsjs/jquery-ui
@@ -21,11 +21,10 @@
 
 (deftask package []
   (comp
-    (download :url      "https://github.com/rwillig/jquery-ui/blob/master/resources/download/jquery-ui-1.11.3.zip?raw="
-              :name     "jquery-ui-1.11.3.zip"
-              :checksum "cb943ac26be9ee755e8741ea232389e2"
+    (download :url      "https://raw.githubusercontent.com/ZabelTech/jquery-ui/master/jquery-ui-1.11.4.zip"
+              :name     "jquery-ui-1.11.4.zip"
+              :checksum "C578DE5FEAECA4190EF89E00519E91DC"
               :unzip    true)
-    (sift :include #{#"^jquery-ui-(.*)/external/(.*).js"} :invert true)
     (sift :move {#"^jquery-ui-(.*)/([a-zA-Z-]+).js"                 "cljsjs/development/$2.inc.js"
                  #"^jquery-ui-(.*)/([a-zA-Z-]+).min.js"             "cljsjs/production/$2.min.inc.js"
                  #"^jquery-ui-(.*)/([a-zA-Z-]+).min.css"            "cljsjs/common/css/$2.min.inc.css"
@@ -35,4 +34,4 @@
                  })
     (sift :include #{#"^cljsjs"})
     (deps-cljs :name "cljsjs.jquery-ui"
-               :requires ["cljsjs.jquery"])))
+               :requires ["cljsjs.jquery" "cljsjs.jquery-ui"])))

--- a/jquery/README.md
+++ b/jquery/README.md
@@ -2,7 +2,7 @@
 
 [](dependency)
 ```clojure
-[cljsjs/jquery "1.9.0-0"] ;; latest release
+[cljsjs/jquery "2.1.1-0"] ;; latest release
 ```
 [](/dependency)
 

--- a/jquery/build.boot
+++ b/jquery/build.boot
@@ -6,7 +6,7 @@
 (require '[adzerk.bootlaces :refer :all]
          '[cljsjs.boot-cljsjs.packaging :refer :all])
 
-(def +version+ "1.9.0-0")
+(def +version+ "2.1.1-0")
 
 (task-options!
   pom  {:project     'cljsjs/jquery
@@ -18,10 +18,10 @@
 
 (deftask package []
   (comp
-    (download :url "http://code.jquery.com/jquery-1.9.0.js"
-              :checksum "f3346149a7173e70d39e6f36bfb178a4")
-    (download :url "http://code.jquery.com/jquery-1.9.0.min.js"
-              :checksum "0652da382b6fceb033dfe2b6c06d4d11")
+    (download :url "http://code.jquery.com/jquery-2.1.1.js"
+              :checksum "7403060950F4A13BE3B3DFDE0490EE05")
+    (download :url "http://code.jquery.com/jquery-2.1.1.min.js"
+              :checksum "E40EC2161FE7993196F23C8A07346306")
     (sift :move {#"jquery-([\d\.]*).js" "cljsjs/development/jquery.inc.js"
                  #"jquery-([\d\.]*).min.js" "cljsjs/production/jquery.min.inc.js"})
     (sift :include #{#"^cljsjs"})


### PR DESCRIPTION
Hello,
i needed the newest JQuery and packagged it along with the JQuery Ui.
Since in jquery-ui there is the require for jquery, i removed the sift include to the really old version of jquery in the /externals/ path of the jquery-ui archive.
