### PR TITLE
Add juration.js

### DIFF
--- a/juration/README.md
+++ b/juration/README.md
@@ -19,7 +19,7 @@ you can require the packaged library like so:
 
 [flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
 
-Note: This extern pulls directly from the github master branch as there are no released downloads. If you know of one please submit a PR. 
+Note: This extern pulls directly from a commit for 0.0.1 as there are no released downloads. If you know of one please submit a PR. 
 
 ## Example usage
 

--- a/juration/README.md
+++ b/juration/README.md
@@ -1,0 +1,32 @@
+# cljsjs/juration
+
+A cljs interface to [juration](https://github.com/domchristie/juration) - A simple natural language duration parser written in javascript.
+
+[](dependency)
+```clojure
+[cljsjs/juration "0.0.1"] ;; latest release
+```
+[](/dependency)
+
+This jar comes with `deps.cljs` as used by the [Foreign Libs][flibs] feature
+of the Clojurescript compiler. After adding the above dependency to your project
+you can require the packaged library like so:
+
+```clojure
+(ns application.core
+  (:require cljsjs.juration))
+```
+
+[flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
+
+Note: This extern pulls directly from the github master branch as there are no released downloads. If you know of one please submit a PR. 
+
+## Example usage
+
+```clojure
+(.parse js/juration "45m")
+```
+
+```clojure
+(.stringify js/juration 2000))
+```

--- a/juration/build.boot
+++ b/juration/build.boot
@@ -22,7 +22,7 @@
 
 (deftask package []
   (comp
-    (download :url      "https://raw.githubusercontent.com/domchristie/juration/master/juration.js"
+    (download :url      "https://raw.githubusercontent.com/domchristie/juration/531b9d35a1e7af5a946f3da920b9d562bdca3fd2/juration.js"
               :name 	"juration.js"
 	      :unzip    false)
     (minify :in "juration.js" :out "juration.min.js")

--- a/juration/build.boot
+++ b/juration/build.boot
@@ -1,0 +1,33 @@
+(set-env!
+  :resource-paths #{"resources"}
+  :dependencies '[[adzerk/bootlaces   "0.1.9" :scope "test"]
+                  [cljsjs/boot-cljsjs "0.4.6" :scope "test"]])
+
+(require '[adzerk.bootlaces :refer :all]
+         '[cljsjs.boot-cljsjs.packaging :refer :all])
+
+(def +version+ "0.0.1")
+(bootlaces! +version+)
+
+
+(task-options!
+ pom  {:project     'cljsjs/juration
+       :version     +version+
+       :description "Human friendly time duration parsing."
+       :url         "https://github.com/domchristie/juration"
+       :scm         {:url "https://github.com/cljsjs/packages"}
+       :license     {"MIT" "http://opensource.org/licenses/MIT"}})
+
+(require '[clojure.java.io :as io])
+
+(deftask package []
+  (comp
+    (download :url      "https://raw.githubusercontent.com/domchristie/juration/master/juration.js"
+              :name 	"juration.js"
+	      :unzip    false)
+    (minify :in "juration.js" :out "juration.min.js")
+    (sift :move {#"juration.js"    "cljsjs/development/juration.inc.js"
+		#"juration.min.js" "cljsjs/production/juration.min.inc.js"
+		})
+    (sift :include #{#"^cljsjs"})
+    (deps-cljs :name "cljsjs.juration")))

--- a/juration/resources/cljsjs/common/juration.ext.js
+++ b/juration/resources/cljsjs/common/juration.ext.js
@@ -1,0 +1,4 @@
+var juration = {
+    "parse": function () {},
+    "stringify": function () {}
+};


### PR DESCRIPTION
Add [juration.js](https://github.com/domchristie/juration) - for parsing time durations in natural language form. This cljsjs package was required to work around a lack of released juration versions.