### PR TITLE
package the kemia library

### DIFF
--- a/kemia/README.md
+++ b/kemia/README.md
@@ -1,0 +1,20 @@
+# cljsjs/kemia
+
+[](dependency)
+```clojure
+[cljsjs/kemia "0.2.0"] ;; latest release
+```
+[](/dependency)
+
+This jar comes with `deps.cljs` providing Kemia  **as a Closure library**.
+This means requiring parts of it is done in a similar fashion to
+requiring parts of the Closure library itself:
+
+```clojure
+(ns application.core
+  (:require [goog.dom :as dom]          ; Closure
+            [kemia.model.Atom :as Atom]))   ; Kemia
+```
+
+
+

--- a/kemia/README.md
+++ b/kemia/README.md
@@ -16,5 +16,5 @@ requiring parts of the Closure library itself:
             [kemia.model.Atom :as Atom]))   ; Kemia
 ```
 
-
+Kemia homepage can be found [here](http://kemia.github.io/)
 

--- a/kemia/build.boot
+++ b/kemia/build.boot
@@ -21,7 +21,7 @@
     (download :url "https://github.com/kemia/kemia/archive/v0.2.zip"
               :checksum "DED3B45E53C56188758F964EDAB08344"
               :unzip true)
-    (sift :move {#"^kemia-([\d\.]*)/kemia/" "cljsjs/development/kemia/"
-                 #"^kemia-([\d\.]*)/css/kemia.css" "cljsjs/common/kemia.inc.css"})
+    (sift :move {#"^kemia-([\d\.]*)/kemia/" "cljsjs/kemia/development/"
+                 #"^kemia-([\d\.]*)/css/kemia.css" "cljsjs/kemia/common/kemia.inc.css"})
     (sift :include #{#"^cljsjs/" #"deps.cljs"})))
 

--- a/kemia/build.boot
+++ b/kemia/build.boot
@@ -1,0 +1,27 @@
+(set-env!
+  :resource-paths #{"resources"}
+  :dependencies '[[adzerk/bootlaces   "0.1.9" :scope "test"]
+                  [cljsjs/boot-cljsjs "0.4.6" :scope "test"]])
+
+(require '[adzerk.bootlaces :refer :all]
+         '[cljsjs.boot-cljsjs.packaging :refer :all])
+
+(def +version+ "0.2.0")
+
+(task-options!
+ pom  {:project     'cljsjs/kemia
+       :version     +version+
+       :description "A chemical structure library"
+       :url         "http://kemia.github.io/"
+       :scm         {:url "https://github.com/cljsjs/packages"}
+       :license     {"Apache" "http://www.apache.org/licenses/"}})
+
+(deftask package []
+  (comp
+    (download :url "https://github.com/kemia/kemia/archive/v0.2.zip"
+              :checksum "DED3B45E53C56188758F964EDAB08344"
+              :unzip true)
+    (sift :move {#"^kemia-([\d\.]*)/kemia/" "cljsjs/development/kemia/"
+                 #"^kemia-([\d\.]*)/css/kemia.css" "cljsjs/common/kemia.inc.css"})
+    (sift :include #{#"^cljsjs/" #"deps.cljs"})))
+

--- a/kemia/resources/deps.cljs
+++ b/kemia/resources/deps.cljs
@@ -1,0 +1,1 @@
+{:libs ["cljsjs/development/kemia/"]}

--- a/kemia/resources/deps.cljs
+++ b/kemia/resources/deps.cljs
@@ -1,1 +1,1 @@
-{:libs ["cljsjs/development/kemia/"]}
+{:libs ["cljsjs/kemia/development/"]}


### PR DESCRIPTION
Kemia a javascript library built on google-closure. Although not in active development, it is probably the only open source pure-javascript library containing chemistry specific algorithms like ring-finding and chemical layout. I think this would be a nice addition to cljsjs  and I intend to also package [chemdoodle webcomponents](http://web.chemdoodle.com/) in order to provide a decent cljs-based in-the-brower chemistry toolset.

This build and the JAR works on my machine using the  [Quick Start](https://github.com/clojure/clojurescript/wiki/Quick-Start) instructions.