### PR TITLE
Enable advanced compilation for gl-matrix

### DIFF
--- a/gl-matrix/README.md
+++ b/gl-matrix/README.md
@@ -15,7 +15,7 @@ to date as of 2015-04-09.
 
 [](dependency)
 ```clojure
-[cljsjs/gl-matrix "2.3.0-jenanwise-0"] ;; latest release
+[cljsjs/gl-matrix "2.3.0-jenanwise-1"] ;; latest release
 ```
 [](/dependency)
 

--- a/gl-matrix/build.boot
+++ b/gl-matrix/build.boot
@@ -7,7 +7,7 @@
          '[cljsjs.boot-cljsjs.packaging :refer :all])
 
 (def gl-matrix-version "2.3.0-jenanwise")
-(def +version+ (str gl-matrix-version "-0"))
+(def +version+ (str gl-matrix-version "-1"))
 (bootlaces! +version+)
 
 (task-options!
@@ -30,5 +30,9 @@
                 "cljsjs/gl-matrix/development/gl-matrix.inc.js"
                 #"^gl-matrix-min.js"
                 "cljsjs/gl-matrix/production/gl-matrix.min.inc.js"})
+   (replace-content :in "cljsjs/gl-matrix/development/gl-matrix.inc.js"
+                    :match #"exports" :value "global")
+   (replace-content :in "cljsjs/gl-matrix/production/gl-matrix.min.inc.js"
+                    :match #"exports" :value "global")
    (sift :include #{#"^cljsjs"})
    (deps-cljs :name "cljsjs.gl-matrix")))

--- a/jszip/build.boot
+++ b/jszip/build.boot
@@ -1,0 +1,35 @@
+(set-env!
+ :resource-paths #{"resources"}
+ :dependencies '[[adzerk/bootlaces "0.1.11" :scope "test"]
+                 [cljsjs/boot-cljsjs "0.5.0" :scope "test"]])
+
+(require '[adzerk.bootlaces :refer :all]
+         '[cljsjs.boot-cljsjs.packaging :refer :all])
+
+(def jszip-version "2.5.0")
+(def +version+ (str jszip-version))
+(bootlaces! +version+)
+
+(task-options!
+ pom {:project 'cljsjs/jszip
+      :version +version+
+      :description "Create, read and edit .zip files"
+      :url "http://stuk.github.io/jszip/"
+      :scm {:url "https://github.com/Stuk/jszip"}
+      :license {"MIT" "http://opensource.org/licenses/MIT"
+                "GPLv3" "http://www.gnu.org/licenses/gpl-3.0.en.html"}})
+
+(deftask package []
+  (comp
+   (download
+    :url "https://raw.githubusercontent.com/Stuk/jszip/v2.5.0/dist/jszip.js"
+    :checksum "b2b9eb4084c03189e0c32bac39f9f44b")
+   (download
+    :url "https://raw.githubusercontent.com/Stuk/jszip/v2.5.0/dist/jszip.min.js"
+    :checksum "88731e24340ce38647f6d595f0e464cb")
+   (sift :move {#"^jszip.js"
+                "cljsjs/jszip/development/jszip.inc.js"
+                #"^jszip.min.js"
+                "cljsjs/gl-matrix/production/jszip.min.inc.js"})
+   (sift :include #{#"^cljsjs"})
+   (deps-cljs :name "cljsjs.jszip")))

--- a/jszip/resources/cljsjs/jszip/common/jszip.ext.js
+++ b/jszip/resources/cljsjs/jszip/common/jszip.ext.js
@@ -1,0 +1,48 @@
+/**
+ * @constructor
+ */
+var JSZip = function() {};
+
+/**
+ * @constructor
+ */
+var ZipObject = function() {};
+
+/**
+ * @param  {string|ArrayBuffer|Uint8Array|Buffer} data
+ * @param  {Object=} options
+ * @return {JSZip}
+ */
+JSZip.prototype.load = function(data, options) {};
+
+/**
+ * @param  {string|RegExp} name
+ * @param  {string|ArrayBuffer|Uint8Array|Buffer=} data
+ * @param  {Object=} options
+ * @return {ZipObject|Array.<ZipObject>|JSZip}
+ */
+JSZip.prototype.file = function(name, data, options) {};
+
+/**
+ * @param  {string|RegExp} name
+ * @return {JSZip|Array.<ZipObject>}
+ */
+JSZip.prototype.folder = function(name) {};
+
+/**
+ * @param  {Function} predicate
+ * @return {Array.<ZipObject>}
+ */
+JSZip.prototype.filter = function(predicate) {};
+
+/**
+ * @param  {string} name
+ * @return {JSZip}
+ */
+JSZip.prototype.remove = function(predicate) {};
+
+/**
+ * @param  {Object} options
+ * @return {string|Uint8Array|ArrayBuffer|Blob|Buffer}
+ */
+JSZip.prototype.generate = function(options) {};

--- a/jszip/resources/cljsjs/jszip/common/jszip.ext.js
+++ b/jszip/resources/cljsjs/jszip/common/jszip.ext.js
@@ -46,3 +46,68 @@ JSZip.prototype.remove = function(predicate) {};
  * @return {string|Uint8Array|ArrayBuffer|Blob|Buffer}
  */
 JSZip.prototype.generate = function(options) {};
+
+/**
+ * @type {string}
+ */
+ZipObject.prototype.name;
+
+/**
+ * @type {boolean}
+ */
+ZipObject.prototype.dir;
+
+/**
+ * @type {boolean}
+ */
+ZipObject.prototype.dir;
+
+/**
+ * @type {Date}
+ */
+ZipObject.prototype.date;
+
+/**
+ * @type {string}
+ */
+ZipObject.prototype.comment;
+
+/**
+ * @type {number}
+ */
+ZipObject.prototype.unixPermissions;
+
+/**
+ * @type {number}
+ */
+ZipObject.prototype.dosPermissions;
+
+/**
+ * @type {Object}
+ */
+ZipObject.prototype.options;
+
+/**
+ * @return {string}
+ */
+ZipObject.prototype.asText = function() {};
+
+/**
+ * @return {string}
+ */
+ZipObject.prototype.asBinary = function() {};
+
+/**
+ * @return {ArrayBuffer}
+ */
+ZipObject.prototype.asArrayBuffer = function() {};
+
+/**
+ * @return {Uint8Array}
+ */
+ZipObject.prototype.asUint8Array = function() {};
+
+/**
+ * @return {Buffeer}
+ */
+ZipObject.prototype.asNodeBuffer = function() {};


### PR DESCRIPTION
I'm using gl-matrix in a library project, that is consumed by a larger JS project which uses browserify to build itself. Browserify wraps each module in a closure, and gl-matrix is trying to detect "exports" and export its functions there. But the CLJS project uses `js/mat3.create` to access it from `global` context. I believe this change doesn't break it for anyone while it enables us to use CLJS libraries in a browserified project. 