### PR TITLE
[glmatrix] Replace exports for global to enabled advanced compilation

### DIFF
--- a/gl-matrix/README.md
+++ b/gl-matrix/README.md
@@ -15,7 +15,7 @@ to date as of 2015-04-09.
 
 [](dependency)
 ```clojure
-[cljsjs/gl-matrix "2.3.0-jenanwise-0"] ;; latest release
+[cljsjs/gl-matrix "2.3.0-jenanwise-1"] ;; latest release
 ```
 [](/dependency)
 

--- a/gl-matrix/build.boot
+++ b/gl-matrix/build.boot
@@ -7,7 +7,7 @@
          '[cljsjs.boot-cljsjs.packaging :refer :all])
 
 (def gl-matrix-version "2.3.0-jenanwise")
-(def +version+ (str gl-matrix-version "-0"))
+(def +version+ (str gl-matrix-version "-1"))
 (bootlaces! +version+)
 
 (task-options!
@@ -30,5 +30,9 @@
                 "cljsjs/gl-matrix/development/gl-matrix.inc.js"
                 #"^gl-matrix-min.js"
                 "cljsjs/gl-matrix/production/gl-matrix.min.inc.js"})
+   (replace-content :in "cljsjs/gl-matrix/development/gl-matrix.inc.js"
+                    :match #"exports" :value "global")
+   (replace-content :in "cljsjs/gl-matrix/production/gl-matrix.min.inc.js"
+                    :match #"exports" :value "global")
    (sift :include #{#"^cljsjs"})
    (deps-cljs :name "cljsjs.gl-matrix")))


### PR DESCRIPTION
I'm using gl-matrix in a library project, that is consumed by a larger JS project which uses browserify to build itself. Browserify wraps each module in a closure, and gl-matrix is trying to detect "exports" and export its functions there. But the CLJS project uses js/mat3.create to access it from global context. I believe this change doesn't break it for anyone while it enables us to use CLJS libraries in a browserified project.