### PR TITLE
Fix firebase extern compile error.

### DIFF
--- a/firebase/resources/cljsjs/common/firebase.ext.js
+++ b/firebase/resources/cljsjs/common/firebase.ext.js
@@ -4,8 +4,6 @@
    Updated with new functions from v2.1.2
 */
 
-var Firebase, FirebaseDataSnapshot, FirebaseSimpleLogin;
-
 /**
    @param {string} firebaseURL
    @constructor


### PR DESCRIPTION
checkVars defaults to ERROR

>> tmp/bower_components/firebase-extern/index.js:13: ERROR - Variable Firebase first declared in tmp/bower_components/firebase-extern/index.js
>> var Firebase = function(firebaseURL) {};