### PR TITLE
[web-animations-js] Added 2.1.2.

### DIFF
--- a/web-animations-js/README.md
+++ b/web-animations-js/README.md
@@ -1,0 +1,20 @@
+# cljsjs/web-animations-js
+
+[](dependency)
+```clojure
+[cljsjs/web-animations-js "2.1.2-0"] ;; latest release
+```
+[](/dependency)
+
+This jar comes with `deps.cljs` as used by the [Foreign Libs][flibs] feature
+of the Clojurescript compiler. After adding the above dependency to your project
+you can require the packaged library like so:
+
+```clojure
+(ns application.core
+  (:require cljsjs.web-animations-js))
+```
+
+`web-animations-js` polyfills Web Animations [W3C spec](http://w3c.github.io/web-animations/).
+
+[flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies

--- a/web-animations-js/build.boot
+++ b/web-animations-js/build.boot
@@ -1,0 +1,26 @@
+(set-env!
+  :resource-paths #{"resources"}
+  :dependencies '[[adzerk/bootlaces   "0.1.11" :scope "test"]
+                  [cljsjs/boot-cljsjs "0.5.0" :scope "test"]])
+
+(require '[adzerk.bootlaces :refer :all]
+         '[cljsjs.boot-cljsjs.packaging :refer :all])
+
+(def +lib-version+ "2.1.2")
+(def +version+ (str +lib-version+ "-0"))
+
+(task-options!
+ pom  {:project     'cljsjs/web-animations-js
+       :version     +version+
+       :description "A polyfill for Web Animations"
+       :url         "https://github.com/web-animations/web-animations-js"
+       :scm         {:url "https://github.com/cljsjs/packages"}
+       :license     {"MIT" "http://opensource.org/licenses/MIT"}})
+
+(deftask package []
+  (comp
+    (download :url (str "https://github.com/web-animations/web-animations-js/archive/" +lib-version+ ".zip") :unzip true)
+    (sift :move {#"web-animations-js-([\d\.]*)/web-animations.min.js" "cljsjs/development/web-animations-js.inc.js"
+                 #"web-animations-js-([\d\.]*)/web-animations.min.js" "cljsjs/production/web-animations-js.min.inc.js"})
+    (sift :include #{#"^cljsjs"})
+    (deps-cljs :name "cljsjs.web-animations-js")))

--- a/web-animations-js/resources/cljsjs/web-animations-js/common/web-animations-js.ext.js
+++ b/web-animations-js/resources/cljsjs/web-animations-js/common/web-animations-js.ext.js
@@ -1,0 +1,1 @@
+Element.prototype.animate = function(frames, options) {};


### PR DESCRIPTION
[web-animations-js](https://github.com/web-animations/web-animations-js) does not come with usable non minified js so I just use the `min` for both `inc.js`. Not sure this case is supposed to be addressed.