### PR TITLE
[auth0-lock] add library @ 7.7.1

### DIFF
--- a/auth0-lock/README.md
+++ b/auth0-lock/README.md
@@ -1,0 +1,20 @@
+# cljsjs/auth0 -lock
+
+[](dependency)
+```clojure
+[cljsjs/auth0-lock "7.7.1-0"] ;; latest release
+```
+[](/dependency)
+
+This jar comes with `deps.cljs` as used by the [Foreign Libs][flibs] feature
+of the Clojurescript compiler. After adding the above dependency to your project
+you can require the packaged library like so:
+
+```clojure
+(ns application.core
+  (:require cljsjs.auth0))
+```
+
+Documentation for the auth0-lock lib can be found [on its github page](https://github.com/auth0/lock)
+
+[flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies

--- a/auth0-lock/build.boot
+++ b/auth0-lock/build.boot
@@ -1,0 +1,28 @@
+(set-env!
+  :resource-paths #{"resources"}
+  :dependencies '[[adzerk/bootlaces   "0.1.10" :scope "test"]
+                  [cljsjs/boot-cljsjs "0.5.0" :scope "test"]])
+
+(require '[adzerk.bootlaces :refer :all]
+         '[cljsjs.boot-cljsjs.packaging :refer :all])
+
+(def auth0-lock-version "7.7.1")
+(def +version+ (str auth0-lock-version "-0"))
+(bootlaces! +version+)
+
+(task-options!
+ pom { :project     'cljsjs/auth0-lock
+       :version     +version+
+       :description "Auth0 Lock"
+       :url         "https://auth0.com/docs/libraries/lock"
+       :scm         { :url "https://github.com/auth0/lock" }
+       :license     { "MIT" "https://github.com/auth0/lock/blob/master/LICENSE" }})
+
+(deftask package []
+  (comp
+    (download :url "https://github.com/auth0/lock/archive/v7.7.1.zip"
+              :unzip true)
+    (sift :move { #"^lock.*/build/auth0-lock\.js$"      "cljsjs/auth0-lock/development/auth0-lock.inc.js"
+                  #"^lock.*/build/auth0-lock\.min\.js$" "cljsjs/auth0-lock/production/auth0-lock.min.inc.js" })
+    (sift :include #{#"^cljsjs"})
+    (deps-cljs :name "cljsjs.auth0-lock")))

--- a/auth0-lock/resources/cljsjs/auth0-lock/common/auth0-lock.ext.js
+++ b/auth0-lock/resources/cljsjs/auth0-lock/common/auth0-lock.ext.js
@@ -1,0 +1,146 @@
+/**
+ * @externs
+ */
+
+/**
+ * @param {Object} options
+ * @constructor
+ */
+var Auth0 = function (options) {};
+
+/**
+ * @type {string}
+ */
+Auth0.version;
+
+/**
+ * @param {string} id_token
+ * @param {function} callback
+ * @return {undefined}
+ */
+Auth0.prototype.getProfile = function (id_token, callback) {};
+
+/**
+ * @param {String} clientID
+ * @param {String} domain
+ * @param {Object} options
+ *     - cdn
+ *     - assetsUrl
+ * @return {Auth0Lock}
+ * @constructor
+ */
+var Auth0Lock = function (clientID, domain, options) {};
+
+
+/**
+ * @type {string}
+ */
+Auth0Lock.version;
+
+
+Auth0Lock.prototype.showNetworkError = function () {};
+
+/**
+ * @param {String} selector
+ * @param {NodeElement} context
+ * @return {BonzoAugmented}
+ * @public
+ */
+Auth0Lock.prototype.query = function (selector, context) {};
+
+/**
+ * @param {Function} tmpl
+ * @param {Object} locals
+ * @return {String}
+ * @public
+ */
+Auth0Lock.prototype.render = function (tmpl, locals) {};
+
+/**
+ * @param {Object} options
+ * @param {Function} callback
+ * @return {Auth0Lock}
+ * @public
+ */
+Auth0Lock.prototype.show = function (options, callback) {};
+
+/**
+ * @param {Object} options
+ * @param {Function} callback
+ * @return {Auth0Lock}
+ * @public
+ */
+Auth0Lock.prototype.showSignin = function (options, callback) {};
+
+/**
+ * @param {Object} options
+ * @param {Function} callback
+ * @return {Auth0Lock}
+ * @public
+ */
+Auth0Lock.prototype.showSignup = function (options, callback) {};
+
+/**
+ * @param {Object} options
+ * @param {Function} callback
+ * @return {Auth0Lock}
+ * @public
+ */
+Auth0Lock.prototype.showReset = function (options, callback) {};
+
+/**
+ * @param {Function} callback
+ * @return {Auth0Lock}
+ * @public
+ */
+Auth0Lock.prototype.hide = function (callback) {};
+
+/**
+ * @param {Object} query
+ * @return {Auth0Lock}
+ * @public
+ */
+Auth0Lock.prototype.logout = function (query) {};
+
+/**
+ * @return {Auth0}
+ * @public
+ */
+
+Auth0Lock.prototype.getClient = function () {};
+
+/**
+ * @param {String} hash
+ * @return {Object|Error}
+ * @public
+ */
+
+Auth0Lock.prototype.parseHash = function (hash) {};
+
+/**
+ * @param {String} token
+ * @param {Function} callback
+ * @return {Auth0Lock}
+ * @public
+ */
+Auth0Lock.prototype.getProfile = function (token, callback) {};
+
+/**
+ * @param {String} panelName
+ * @public
+ */
+Auth0Lock.prototype._setPreviousPanel = function (panelName) {};
+
+/**
+ * @return {String}
+ * @public
+ */
+Auth0Lock.prototype._getPreviousPanel = function () {};
+
+/**
+ * @public
+ */
+Auth0Lock.prototype._clearPreviousPanel = function () {};
+
+
+


### PR DESCRIPTION
Hi,
This pull request adds support for auth0-lock, which provides sign-in dialogue boxes for use with auth0. This is not the same library as auth0, which is already in cljsjs.

I have provided extern definitions for all javascript functions that were documented as public. dev and min builds have been tested in a clojurescript project for the main entry points.

This is my first cljsjs contribution, hopefully I have not overlooked anything major. 

Thanks,
Ted
