### PR TITLE
Updating old [Foreign Libs] URLs, add missing references

### DIFF
--- a/auth0/README.md
+++ b/auth0/README.md
@@ -17,4 +17,4 @@ you can require the packaged library like so:
 
 Documentation for the auth0 lib can be found [on its github page](https://github.com/auth0/auth0.js)
 
-[flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies

--- a/c3/README.md
+++ b/c3/README.md
@@ -15,4 +15,4 @@ you can require the packaged library like so:
   (:require cljsjs.c3))
 ```
 
-[flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies

--- a/chance/README.md
+++ b/chance/README.md
@@ -15,4 +15,4 @@ you can require the packaged library like so:
   (:require cljsjs.chance))
 ```
 
-[flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies

--- a/chemdoodle/README.md
+++ b/chemdoodle/README.md
@@ -15,5 +15,4 @@ you can require the packaged library like so:
   (:require cljsjs.chemdoodle))
 ```
 
-[flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
-
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies

--- a/classnames/README.md
+++ b/classnames/README.md
@@ -15,4 +15,4 @@ you can require the packaged library like so:
   (:require cljsjs.classnames))
 ```
 
-[flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies

--- a/css-layout/README.md
+++ b/css-layout/README.md
@@ -15,4 +15,4 @@ you can require the packaged library like so:
   (:require cljsjs.css-layout))
 ```
 
-[flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies

--- a/csv/README.md
+++ b/csv/README.md
@@ -15,4 +15,4 @@ you can require the packaged library like so:
   (:require cljsjs.csv))
 ```
 
-[flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies

--- a/d3/README.md
+++ b/d3/README.md
@@ -17,4 +17,4 @@ you can require the packaged library like so:
 
 Uses externs provided by `federico-b/d3-externs`, many thanks!
 
-[flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies

--- a/device/README.md
+++ b/device/README.md
@@ -15,4 +15,4 @@ you can require the packaged library like so:
   (:require cljsjs.device))
 ```
 
-
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies

--- a/dimple/README.md
+++ b/dimple/README.md
@@ -16,3 +16,5 @@ you can require the packaged library like so:
 ```
 
 No proper externs yet - just figuring things out at the moment....
+
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies

--- a/document-register-element/README.md
+++ b/document-register-element/README.md
@@ -17,4 +17,4 @@ you can require the packaged library like so:
 
 `document-register-element` polyfills the Custom Elements specification. Related methods are already defined in externs packaged by the closure compiler thus this module is extern free.
 
-[flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies

--- a/dom4/README.md
+++ b/dom4/README.md
@@ -17,4 +17,4 @@ you can require the packaged library like so:
 
 `dom4` polyfills DOM4 parentNodes/childNodes entries.
 
-[flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies

--- a/dropbox/README.md
+++ b/dropbox/README.md
@@ -15,4 +15,4 @@ you can require the packaged library like so:
   (:require cljsjs.dropbox))
 ```
 
-[flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies

--- a/fabric/README.md
+++ b/fabric/README.md
@@ -15,4 +15,4 @@ you can require the packaged library like so:
   (:require cljsjs.fabric))
 ```
 
-[flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies

--- a/fastclick/README.md
+++ b/fastclick/README.md
@@ -15,4 +15,4 @@ you can require the packaged library like so:
   (:require cljsjs.fastclick))
 ```
 
-[flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies

--- a/firebase/README.md
+++ b/firebase/README.md
@@ -15,4 +15,4 @@ you can require the packaged library like so:
   (:require cljsjs.firebase))
 ```
 
-[flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies

--- a/fixed-data-table/README.md
+++ b/fixed-data-table/README.md
@@ -14,3 +14,5 @@ you can require the packaged library like so:
 (ns application.core
   (:require cljsjs.fixed-data-table))
 ```
+
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies

--- a/flot/README.md
+++ b/flot/README.md
@@ -30,5 +30,4 @@ cljsjs.flot.plugins.resize
 cljsjs.flot.plugins.selection
 ```
 
-[flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
-
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies

--- a/gl-matrix/README.md
+++ b/gl-matrix/README.md
@@ -31,4 +31,4 @@ to can require the packaged library like so:
   (:require cljsjs.gl-matrix))
 ```
 
-[flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies

--- a/google-maps/README.md
+++ b/google-maps/README.md
@@ -11,5 +11,4 @@ of the Clojurescript compiler.
 
 The jar only provides an extern file required for advanced compilation.
 The Google Maps js API will still need to provided through some other mechanism.
-[flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
-
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies

--- a/hammer/README.md
+++ b/hammer/README.md
@@ -15,4 +15,4 @@ you can require the packaged library like so:
   (:require cljsjs.hammer))
 ```
 
-[flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies

--- a/hashids/README.md
+++ b/hashids/README.md
@@ -15,4 +15,4 @@ you can require the packaged library like so:
   (:require cljsjs.hashids))
 ```
 
-[flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies

--- a/heap/README.md
+++ b/heap/README.md
@@ -10,5 +10,4 @@ of the Clojurescript compiler.
 
 The jar only provides an extern file required for advanced compilation.
 The Heap js API will still need to be provided through some other mechanism.
-[flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
-
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies

--- a/highlight/README.md
+++ b/highlight/README.md
@@ -136,5 +136,4 @@ cljsjs.highlight.langs.xl
 cljsjs.highlight.langs.xml
 ```
 
-[flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
-
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies

--- a/jquery-daterange-picker/README.md
+++ b/jquery-daterange-picker/README.md
@@ -15,4 +15,4 @@ you can require the packaged library like so:
   (:require cljsjs.jquery-daterange-picker))
 ```
 
-[flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies

--- a/jquery-ui/README.md
+++ b/jquery-ui/README.md
@@ -15,4 +15,4 @@ you can require the packaged library like so:
   (:require cljsjs.jquery-ui))
 ```
 
-[flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies

--- a/jquery/README.md
+++ b/jquery/README.md
@@ -15,4 +15,4 @@ you can require the packaged library like so:
   (:require cljsjs.jquery))
 ```
 
-[flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies

--- a/js-yaml/README.md
+++ b/js-yaml/README.md
@@ -14,5 +14,4 @@ you can require the packaged library like so:
 (ns application.core
   (:require cljsjs.js-yaml))
 ```
-
-[flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies

--- a/jsdiff/README.md
+++ b/jsdiff/README.md
@@ -15,4 +15,4 @@ you can require the packaged library like so:
   (:require cljsjs.jsdiff))
 ```
 
-[flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies

--- a/juration/README.md
+++ b/juration/README.md
@@ -17,9 +17,9 @@ you can require the packaged library like so:
   (:require cljsjs.juration))
 ```
 
-[flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies
 
-Note: This extern pulls directly from a commit for 0.0.1 as there are no released downloads. If you know of one please submit a PR. 
+Note: This extern pulls directly from a commit for 0.0.1 as there are no released downloads. If you know of one please submit a PR.
 
 ## Example usage
 

--- a/klayjs/README.md
+++ b/klayjs/README.md
@@ -36,4 +36,4 @@ you can require the packaged library like so:
                              :error   (fn [err] (js/console.log "Layout error: " err))}))
 ```
 
-[flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies

--- a/leaflet/README.md
+++ b/leaflet/README.md
@@ -15,7 +15,7 @@ you can require the packaged library like so:
   (:require cljsjs.leaflet))
 ```
 
-[flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies
 
 Note: This extern is a work in progress. You may need to add symbols
 as needed. For example:

--- a/markdown/README.md
+++ b/markdown/README.md
@@ -15,5 +15,4 @@ you can require the packaged library like so:
   (:require cljsjs.markdown))
 ```
 
-[flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
-
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies

--- a/matter/README.md
+++ b/matter/README.md
@@ -17,4 +17,4 @@ you can require the packaged library like so:
 
 Documentation for the matter.js lib can be found [on its github page](https://github.com/liabru/matter-js)
 
-[flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies

--- a/media-stream-recorder/README.md
+++ b/media-stream-recorder/README.md
@@ -16,7 +16,7 @@ you can require the packaged library like so:
 ```
 
 From there
-[flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies
 
 Media Stream Recorder
 

--- a/medium-editor/README.md
+++ b/medium-editor/README.md
@@ -15,4 +15,4 @@ you can require the packaged library like so:
   (:require cljsjs.medium-editor))
 ```
 
-[flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies

--- a/moment/README.md
+++ b/moment/README.md
@@ -27,4 +27,4 @@ You should be able to set Moment to use locales if you first require them.
 (.locale js/moment "fi")
 ```
 
-[flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies

--- a/mui/README.md
+++ b/mui/README.md
@@ -15,4 +15,4 @@ you can require the packaged library like:
   (:require [cljsjs.mui]))
 ```
 
-[flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies

--- a/mustache/README.md
+++ b/mustache/README.md
@@ -15,4 +15,4 @@ you can require the packaged library like so:
   (:require cljsjs.mustache))
 ```
 
-[flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies

--- a/oauthio/README.md
+++ b/oauthio/README.md
@@ -16,5 +16,4 @@ your project, you can require the packaged library like so:
  (:require cljsjs.oauthio))
 ```
 
-[flibs]:
-https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies

--- a/object-assign-shim/README.md
+++ b/object-assign-shim/README.md
@@ -14,3 +14,5 @@ you can require the packaged library like so:
 (ns application.core
   (:require cljsjs.object-assign-shim))
 ```
+
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies

--- a/openlayers/README.md
+++ b/openlayers/README.md
@@ -33,5 +33,4 @@ To rely on the default (canvas based) renderer use:
 
 Dig the [source code](https://github.com/openlayers/ol3/blob/master/src/ol/ol.js) for more defines.
 
-[flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
-
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies

--- a/pako/README.md
+++ b/pako/README.md
@@ -32,4 +32,4 @@ you can require the packaged library like so:
 ```
 
 
-[flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies

--- a/papaparse/README.md
+++ b/papaparse/README.md
@@ -15,4 +15,4 @@ you can require the packaged library like so:
   (:require cljsjs.papaparse))
 ```
 
-[flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies

--- a/peg/README.md
+++ b/peg/README.md
@@ -17,4 +17,4 @@ you can require the packaged library like so:
 
 Usage documentation [for PEG.js](http://pegjs.org/).
 
-[flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies

--- a/pikaday/README.md
+++ b/pikaday/README.md
@@ -22,4 +22,4 @@ or if you want to use pikadays optional Moment.js integration:
   (:require cljsjs.pikaday.with-moment))
 ```
 
-[flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies

--- a/pouchdb/README.md
+++ b/pouchdb/README.md
@@ -15,4 +15,4 @@ you can require the packaged library like so:
   (:require cljsjs.pouchdb))
 ```
 
-[flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies

--- a/react-bootstrap/README.md
+++ b/react-bootstrap/README.md
@@ -31,3 +31,5 @@ then compile your cljs project e.g:
 ```sh
 boot cljs less
 ```
+
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies

--- a/react-router/README.md
+++ b/react-router/README.md
@@ -14,3 +14,5 @@ you can require the packaged library like so:
 (ns application.core
   (:require cljsjs.react-router))
 ```
+
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies

--- a/react/README.md
+++ b/react/README.md
@@ -33,4 +33,4 @@ src/cljs/deps.cljs:
 {:foreign-libs [{:provides ["cljs.react"] :file-min "cljsjs/development/react-with-addons.inc.js"}}
 ```
 
-[flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies

--- a/showdown/README.md
+++ b/showdown/README.md
@@ -15,5 +15,4 @@ to can require the packaged library like so:
   (:require cljsjs.showdown))
 ```
 
-[flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
-
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies

--- a/stripe/README.md
+++ b/stripe/README.md
@@ -10,5 +10,4 @@ of the Clojurescript compiler.
 
 The jar only provides an extern file required for advanced compilation.
 The Stripe js API will still need to be provided through some other mechanism.
-[flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
-
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies

--- a/three/README.md
+++ b/three/README.md
@@ -15,4 +15,4 @@ you can require the packaged library like so:
   (:require cljsjs.three))
 ```
 
-[flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies

--- a/topojson/README.md
+++ b/topojson/README.md
@@ -16,4 +16,4 @@ you can require the packaged library like so:
             cljsjs.topojson))
 ```
 
-[flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies

--- a/vega/README.md
+++ b/vega/README.md
@@ -15,4 +15,4 @@ you can require the packaged library like:
   (:require cljsjs.vega))
 ```
 
-[flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies

--- a/waypoints/README.md
+++ b/waypoints/README.md
@@ -16,4 +16,4 @@ so:
   (:require cljsjs.waypoints))
 ```
 
-[flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies


### PR DESCRIPTION
Noticed that all the [Foreign Libs] URLs were broken, and in some cases the `[flibs]` alias was not even defined.

Believe I've substituted the correct link here.

@martinklepsch 