### PR TITLE
[codemirror] Bump version to 5.6.0, also package addons

### DIFF
--- a/codemirror/README.md
+++ b/codemirror/README.md
@@ -2,7 +2,7 @@
 
 [](dependency)
 ```clojure
-[cljsjs/codemirror "5.1.0-2"] ;; latest release
+[cljsjs/codemirror "5.6.0-0"] ;; latest release
 ```
 [](/dependency)
 


### PR DESCRIPTION
CodeMirror comes with a large list of addons that can be opted in to. In
the previous version these weren't being packaged, now they are.