### PR TITLE
[nodejs-externs] patch to 1.0.4-1

### DIFF
--- a/nodejs-externs/README.md
+++ b/nodejs-externs/README.md
@@ -2,7 +2,7 @@
 
 [](dependency)
 ```clojure
-[cljsjs/nodejs-externs "1.0.4-0"] ;; latest release
+[cljsjs/nodejs-externs "1.0.4-1"] ;; latest release
 ```
 [](/dependency)
 

--- a/nodejs-externs/build.boot
+++ b/nodejs-externs/build.boot
@@ -7,7 +7,7 @@
          '[adzerk.bootlaces :refer :all]
          '[cljsjs.boot-cljsjs.packaging :refer :all])
 
-(def +version+ "1.0.4-0")
+(def +version+ "1.0.4-1")
 
 (task-options!
  pom {:project     'cljsjs/nodejs-externs
@@ -34,7 +34,7 @@
 (deftask package []
   (comp
    (download-nodejs-externs)
-   (sift :move {#"^node.js-closure-compiler-externs-.*/([^/]*).js$"
+   (sift :move {#"^node.js-closure-compiler-externs-[^/]*/([^/]*).js$"
                 "cljsjs/nodejs-externs/common/$1.js"})
    (sift :include #{#"^cljsjs"})
    (generate-local-deps)))


### PR DESCRIPTION
@martinklepsch, oh I'm sorry. I've made a mistake.

originally I wrote regex like this (and I tested this `package build-jar`)
```
(sift :move {#"^node.js-closure-compiler-externs-1.0.4/([^/]*).js$"
                "cljsjs/nodejs-externs/common/$1.js"})
```
then secretly push force to this later ( untested :-( )
```
(sift :move {#"^node.js-closure-compiler-externs-.*/([^/]*).js$"
                "cljsjs/nodejs-externs/common/$1.js"})
```
BUT!! 

this moves unwanted contrib, tests, etc. externs (not core nodejs externs) to target.
and It will break down compilation. so I've fixed.