### PR TITLE
[commonmark] Initial package for version 0.22.0

### DIFF
--- a/commonmark/README.md
+++ b/commonmark/README.md
@@ -1,0 +1,25 @@
+# cljsjs/commonmark
+
+[](dependency)
+```clojure
+[cljsjs/commonmark "0.22.0-0"] ;; latest release
+```
+[](/dependency)
+
+This jar comes with `deps.cljs` as used by the [Foreign Libs][flibs] feature
+of the Clojurescript compiler. After adding the above dependency to your project
+you can require the packaged library like so:
+
+```clojure
+(ns application.core
+  (:require cljsjs.commonmark))
+```
+
+[CommonMark][commonmark] is a rationalized version of Markdown syntax. It provides a
+[library][library] with functions for parsing CommonMark documents to an abstract
+syntax tree (AST), manipulating the AST, and rendering the document to HTML or
+to an XML representation of the AST.
+
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies
+[commonmark]: http://commonmark.org/
+[library]: https://github.com/jgm/commonmark.js

--- a/commonmark/build.boot
+++ b/commonmark/build.boot
@@ -1,0 +1,32 @@
+(set-env!
+  :resource-paths #{"resources"}
+  :dependencies '[[adzerk/bootlaces   "0.1.9" :scope "test"]
+                  [cljsjs/boot-cljsjs "0.5.0" :scope "test"]])
+
+(require '[adzerk.bootlaces :refer :all]
+         '[cljsjs.boot-cljsjs.packaging :refer :all])
+
+(def +version+ "0.22.0")
+(def +cljsjs-version+ (str +version+ "-0"))
+
+(task-options!
+  pom  {:project     'cljsjs/commonmark
+        :version     +cljsjs-version+
+        :description "CommonMark is a rationalized version of Markdown syntax.
+                      It provides a library with functions for parsing
+                      CommonMark documents to an abstract syntax tree (AST),
+                      manipulating the AST, and rendering the document to HTML
+                      or to an XML representation of the AST."
+        :url         "https://github.com/jgm/commonmark.js"
+        :license     {"BSD" "https://github.com/jgm/commonmark.js/blob/master/LICENSE"}
+        :scm         {:url "https://github.com/cljsjs/packages"}})
+
+(deftask package []
+  (comp
+   (download  :url (str "https://codeload.github.com/jgm/commonmark.js/zip/" +version+)
+              :checksum "F1570544C2A967891BB9AE2314FE6648"
+              :unzip true)
+   (sift :move {#"^commonmark.js.*/dist/commonmark.js" "cljsjs/development/commonmark.inc.js"})
+   (sift :move {#"^commonmark.js.*/dist/commonmark.min.js" "cljsjs/production/commonmark.min.inc.js"})
+   (sift :include #{#"^cljsjs"})
+   (deps-cljs :name "cljsjs.commonmark")))

--- a/commonmark/resources/cljsjs/common/commonmark.ext.js
+++ b/commonmark/resources/cljsjs/common/commonmark.ext.js
@@ -1,0 +1,117 @@
+/** @const */
+var commonmark = {};
+
+commonmark.Node = function() {};
+
+/** @type {string} */
+commonmark.Node.prototype.type;
+
+/** @type {commonmark.Node|null} */
+commonmark.Node.prototype.firstChild;
+
+/** @type {commonmark.Node|null} */
+commonmark.Node.prototype.lastChild;
+
+/** @type {commonmark.Node|null} */
+commonmark.Node.prototype.next;
+
+/** @type {commonmark.Node|null} */
+commonmark.Node.prototype.prev;
+
+/** @type {commonmark.Node|null} */
+commonmark.Node.prototype.parent;
+
+/** @type {Array} */
+commonmark.Node.prototype.sourcepos;
+
+/** @type {boolean} */
+commonmark.Node.prototype.isContainer;
+
+/** @type {string|null} */
+commonmark.Node.prototype.literal;
+
+/** @type {string|null} */
+commonmark.Node.prototype.info;
+
+/** @type {number|null} */
+commonmark.Node.prototype.level;
+
+/** @type {string|null} */
+commonmark.Node.prototype.listType;
+
+/** @type {boolean|null} */
+commonmark.Node.prototype.listTight;
+
+/** @type {number|null} */
+commonmark.Node.prototype.listStart;
+
+/** @type {string|null} */
+commonmark.Node.prototype.listDelimiter;
+
+/** @param {commonmark.Node} node */
+commonmark.Node.prototype.appendChild = function(node) {};
+
+/** @param {commonmark.Node} node */
+commonmark.Node.prototype.prependChild = function(node) {};
+
+commonmark.Node.prototype.unlink = function() {};
+
+commonmark.Node.prototype.insertAfter = function() {};
+
+commonmark.Node.prototype.insertBefore = function() {};
+
+/** @return {commonmark.NodeWalker} */
+commonmark.Node.prototype.walker = function() {};
+
+commonmark.NodeWalker = function() {};
+
+/** @return {commonmark.NodeWalkerEvent} */
+commonmark.NodeWalker.prototype.next = function() {};
+
+/**
+  * @param {commonmark.Node} node
+  * @param {boolean} entering
+  */
+commonmark.NodeWalker.prototype.resumeAt = function(node, entering) {};
+
+commonmark.NodeWalkerEvent = function() {};
+
+/** @type {boolean} */
+commonmark.NodeWalkerEvent.prototype.entering;
+
+/** @type {commonmark.Node} */
+commonmark.NodeWalkerEvent.prototype.node;
+
+/**
+ * @param {{sourcepos: boolean, smart: boolean, safe: boolean}|null|undefined} opts
+ */
+commonmark.Parser = function(opts) {};
+
+/**
+ * Parses the string and returns the root node of a markdown AST.
+ * @param {string} str
+ * @return {commonmark.Node}
+ */
+commonmark.Parser.prototype.parse = function(str) {};
+
+/**
+ * @param {{sourcepos: boolean, smart: boolean, safe: boolean}|null|undefined} opts
+ */
+commonmark.HtmlRenderer = function(opts) {};
+
+/**
+ * @param {commonmark.Node} node
+ * @return {string}
+ */
+commonmark.HtmlRenderer.prototype.render = function(node) {};
+
+/**
+ * @param {{sourcepos: boolean, smart: boolean, safe: boolean}|null|undefined} opts
+ */
+commonmark.XmlRenderer = function(opts) {};
+
+/**
+ * @param {commonmark.Node} node
+ * @return {string}
+ */
+commonmark.XmlRenderer.prototype.render = function(node) {};


### PR DESCRIPTION
CommonMark is a rationalized version of Markdown syntax. It provides a
library with functions for parsing CommonMark documents to an abstract
syntax tree (AST), manipulating the AST, and rendering the document to HTML or
to an XML representation of the AST.

See:
https://github.com/jgm/commonmark.js
http://commonmark.org/