### PR TITLE
[google-analytics] add package (2015.04.13-0)

### DIFF
--- a/google-analytics/README.md
+++ b/google-analytics/README.md
@@ -1,0 +1,23 @@
+# cljsjs/google-analytics
+
+The latest release as of 2015-09-22 is "2015-04-13" according to the
+[the changelog](https://developers.google.com/analytics/devguides/collection/analyticsjs/changelog).
+
+This is converted to a semver for cljsjs like so:
+
+[](dependency)
+```clojure
+[cljsjs/google-analytics "2015.04.13-0"] ;; latest release
+```
+[](/dependency)
+
+This jar comes with `deps.cljs` as used by the [Foreign Libs][flibs] feature
+of the Clojurescript compiler. After adding the above dependency to your project
+you can require the packaged library like so:
+
+```clojure
+(ns application.core
+  (:require cljsjs.google-analytics))
+```
+
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies

--- a/google-analytics/build.boot
+++ b/google-analytics/build.boot
@@ -1,0 +1,25 @@
+(set-env!
+  :resource-paths #{"resources"}
+  :dependencies '[[adzerk/bootlaces   "0.1.9" :scope "test"]
+                  [cljsjs/boot-cljsjs "0.5.0" :scope "test"]])
+
+(require '[adzerk.bootlaces :refer :all]
+         '[cljsjs.boot-cljsjs.packaging :refer :all])
+
+(def +version+ "2015.04.13-0")
+
+(task-options!
+ pom  {:project     'cljsjs/google-analytics
+       :version     +version+
+       :description "Google Universal Analytics (analytics.js)"
+       :url         "https://developers.google.com/analytics/devguides/collection/analyticsjs/"
+       :scm         {:url "https://github.com/cljsjs/packages"}
+       :license     {"" ""}})
+
+(deftask package []
+  (comp
+    (download :url "https://www.google-analytics.com/analytics.js"
+              :checksum "eed8ec65a6dd9b05eed6d4a02e1439e4")
+    (sift :move {#"analytics.js" "cljsjs/google-analytics/production/google-analytics.inc.js"})
+    (sift :include #{#"^cljsjs"})
+    (deps-cljs :name "cljsjs.google-analytics")))

--- a/google-analytics/resources/cljsjs/google-analytics/common/google-analytics.ext.js
+++ b/google-analytics/resources/cljsjs/google-analytics/common/google-analytics.ext.js
@@ -1,0 +1,88 @@
+/***************************************************************************
+ * Retrieved on 2015-09-22 from
+ * https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/google_universal_analytics_api.js
+ *
+ * The latest release as of 2015-09-22 is 2015-04-13 according to
+ * https://developers.google.com/analytics/devguides/collection/analyticsjs/changelog
+ ***************************************************************************/
+
+/*
+ * Copyright 2015 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Externs for the Google Universal Analytics API (analytics.js).
+ *
+ * The analytics.js API allows the user to choose a name of Google Analytics
+ * object.  This externs file assumes that the name is ‘ga’.  If you include
+ * analytics.js snippet and use a different name, this externs file will not
+ * be useful to you (unless you change the name ‘ga’ to whatever name you’ve
+ * chosen).
+ *
+ * @see https://developers.google.com/analytics/devguides/collection/analyticsjs/method-reference
+ * @externs
+ */
+
+
+/**
+ * @param {string} methodName
+ * @param {...?} var_args
+ * @return {?}
+ */
+function ga(methodName, var_args) {}
+
+/**
+ * @param {string} trackingId
+ * @param {!Object=} opt_configObject
+ * @return {!_GATracker}
+ */
+ga.create = function(trackingId, opt_configObject) {};
+
+/**
+ * @param {string} name
+ * @return {?_GATracker}
+ */
+ga.getByName = function(name) {};
+
+/** @return {!Array<!_GATracker>} */
+ga.getAll = function() {};
+
+
+/** @type {string|undefined} */
+var GoogleAnalyticsObject;
+
+
+/** @interface */
+function _GATracker() {}
+
+/**
+ * @param {string} hitType
+ * @param {!Object=} opt_fieldObject
+ * @return {*}
+ */
+_GATracker.prototype.send = function(hitType, opt_fieldObject) {};
+
+/**
+ * @param {string|!Object} nameOrFieldObject
+ * @param {string|number|!Object|boolean=} opt_value (required if
+ *     nameOrFieldObject is a string)
+ */
+_GATracker.prototype.set = function(nameOrFieldObject, opt_value) {};
+
+/**
+ * @param {string} name
+ * @return {string|number|?Object|boolean}
+ */
+_GATracker.prototype.get = function(name) {};


### PR DESCRIPTION
Hey cljsjs folks, (still new to all this and) noticed there's no google-analytics here so thought I'd take a stab. Was happy to see Google Closure actually [provides externs](https://github.com/google/closure-compiler/tree/master/contrib/externs/google_universal_analytics_api.js) and Google Analytics actually provide [a changelog](https://developers.google.com/analytics/devguides/collection/analyticsjs/changelog?hl=en), so that's what I used.

But now I'm wondering:

- Google Analytics is so popular, I was surprised there's no cljsjs package for it already. Is there no point in having a cljsjs package of it for some reason I don't understand?
- It looks like there are some other libraries that https://github.com/google/closure-compiler/tree/master/contrib/externs provides externs for that aren't in cljsjs. Is it worth feeding these into cljsjs too, perhaps in some automated way?

Thanks in advance for any answers, and hope this PR is actually useful.