### PR TITLE
Fix Codemirror mode tests overwriting modes in some cases

### DIFF
--- a/codemirror/README.md
+++ b/codemirror/README.md
@@ -2,7 +2,7 @@
 
 [](dependency)
 ```clojure
-[cljsjs/codemirror "5.7.0-0"] ;; latest release
+[cljsjs/codemirror "5.7.0-1"] ;; latest release
 ```
 [](/dependency)
 

--- a/codemirror/build.boot
+++ b/codemirror/build.boot
@@ -9,7 +9,7 @@
 (def codemirror-version "5.7.0")
 (def codemirror-checksum "0E203131B66E77DE9DCE32E13D56B812")
 
-(def +version+ (str codemirror-version "-0"))
+(def +version+ (str codemirror-version "-1"))
 
 (task-options!
   pom  {:project     'cljsjs/codemirror
@@ -25,7 +25,6 @@
          '[clojure.string :as string]
          '[boot.util :refer [sh]]
          '[boot.tmpdir :as tmpd])
-
 (defn path->foreign-lib [path]
   {:file     path
    :requires ["cljsjs.codemirror"]
@@ -54,10 +53,10 @@
               :checksum codemirror-checksum)
     (sift :move {#"^CodeMirror-([\d\.]*)/lib/codemirror\.js"    "cljsjs/codemirror/development/codemirror.inc.js"
                  #"^CodeMirror-([\d\.]*)/lib/codemirror\.css"   "cljsjs/codemirror/development/codemirror.css"
-                 #"^CodeMirror-([\d\.]*)/mode/(.*)/(.*).js"     "cljsjs/codemirror/common/mode/$2.js"
-                 #"^CodeMirror-([\d\.]*)/keymap/(.*).js"     "cljsjs/codemirror/common/keymap/$2.js"
-                 #"^CodeMirror-([\d\.]*)/addon/(.*)/(.*).css"   "cljsjs/codemirror/common/addon/$2/$3.css"
-                 #"^CodeMirror-([\d\.]*)/addon/(.*)/(.*).js"    "cljsjs/codemirror/common/addon/$2/$3.js"})
+                 #"^CodeMirror-([\d\.]*)/mode/(.*)/\2\.js"      "cljsjs/codemirror/common/mode/$2.js"
+                 #"^CodeMirror-([\d\.]*)/keymap/(.*)\.js"       "cljsjs/codemirror/common/keymap/$2.js"
+                 #"^CodeMirror-([\d\.]*)/addon/(.*)/(.*)\.css"  "cljsjs/codemirror/common/addon/$2/$3.css"
+                 #"^CodeMirror-([\d\.]*)/addon/(.*)/(.*)\.js"   "cljsjs/codemirror/common/addon/$2/$3.js"})
     (minify    :in       "cljsjs/codemirror/development/codemirror.inc.js"
                :out      "cljsjs/codemirror/production/codemirror.min.inc.js")
     (minify    :in       "cljsjs/codemirror/development/codemirror.css"


### PR DESCRIPTION
The mode js regex was matching both modes and their tests. When tests
were present this was causing the mode test files to overwrite the modes
themselves sometimes (depending on sort order I think).