### PR TITLE
Cljsjs jqconsole

### DIFF
--- a/jqconsole/README.md
+++ b/jqconsole/README.md
@@ -1,6 +1,6 @@
 # cljsjs/jqconsole
 ```clojure
-[cljsjs/jqconsole "2.12.0-0"] ;; latest release
+[cljsjs/jqconsole "2.13.1-0"] ;; latest release
 ```
 Packages up [jq-console](https://github.com/replit/jq-console).
 

--- a/jqconsole/README.md
+++ b/jqconsole/README.md
@@ -1,0 +1,40 @@
+# cljsjs/jqconsole
+```clojure
+[cljsjs/jqconsole "2.12.0-0"] ;; latest release
+```
+Packages up [jq-console](https://github.com/replit/jq-console).
+
+This jar comes with `deps.cljs` as used by the [Foreign Libs][flibs] feature
+of the Clojurescript compiler. After adding the above dependency to your project
+you can require the packaged library like so:
+
+```clojure
+(ns application.core
+  (:require cljsjs.jqconsole))
+```
+
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies
+
+#jq-console  
+  
+A jQuery terminal plugin written in CoffeeScript.  
+  
+This project was spawned because of our need for a simple web terminal plugin   
+for the <a href="http://repl.it">repl.it</a> project. It tries to simulate a low level terminal by providing (almost)  
+raw input/output streams as well as input and output states.  
+  
+Version 2.0 adds baked-in support for rich multi-line prompting and operation  
+queueing.
+  
+  
+##Tested Browsers  
+  
+The plugin has been tested on the following browsers:  
+  
+* IE 9+
+* Chrome
+* Firefox
+* Opera
+* iOS Safari and Chrome
+* Android Chrome
+ 

--- a/jqconsole/build.boot
+++ b/jqconsole/build.boot
@@ -2,12 +2,12 @@
  :resource-paths #{"resources"}
  :dependencies '[[adzerk/bootlaces "0.1.12" :scope "test"]
                  [cljsjs/boot-cljsjs "0.5.0"  :scope "test"]
-                 [cljsjs/jquery "1.9.1-0"]])
+                 [cljsjs/jquery "2.1.4-0"]])
 
 (require '[adzerk.bootlaces :refer :all]
          '[cljsjs.boot-cljsjs.packaging :refer :all])
 
-(def +version+ "2.12.0-0")
+(def +version+ "2.13.1-0")
 (bootlaces! +version+)
 
 (task-options!

--- a/jqconsole/build.boot
+++ b/jqconsole/build.boot
@@ -1,0 +1,33 @@
+(set-env!
+ :resource-paths #{"resources"}
+ :dependencies '[[adzerk/bootlaces "0.1.12" :scope "test"]
+                 [cljsjs/boot-cljsjs "0.5.0"  :scope "test"]
+                 [cljsjs/jquery "1.9.1-0"]])
+
+(require '[adzerk.bootlaces :refer :all]
+         '[cljsjs.boot-cljsjs.packaging :refer :all])
+
+(def +version+ "2.12.0-0")
+(bootlaces! +version+)
+
+(task-options!
+ pom {:project     'cljsjs/jqconsole
+      :version     +version+
+      :description "A jQuery terminal plugin written in CoffeeScript"
+      :url         "http://replit.github.com/jq-console/"
+      :scm         {:url "https://github.com/replit/jq-console"}
+      :license     {"MIT" "http://opensource.org/licenses/MIT"}})
+
+(deftask package []
+  (comp
+   (download  :url      "https://github.com/replit/jq-console/zipball/master"
+              :unzip    true)
+   (sift      :move     {#"^replit-jq-console-(.*)/lib/jqconsole.js"
+                         "cljsjs/jqconsole/development/jqconsole.inc.js"
+                         #"^replit-jq-console-(.*)/jqconsole.min.js"
+                         "cljsjs/jqconsole/production/jqconsole.min.inc.js"
+                         #"^replit-jq-console-(.*)/css/ansi.css"
+                         "cljsjs/jqconsole/common/css/ansi.css"})
+   (sift      :include  #{#"^cljsjs"})
+   (deps-cljs :name     "cljsjs.jqconsole"
+              :requires ["cljsjs.jquery"])))

--- a/jqconsole/build.boot
+++ b/jqconsole/build.boot
@@ -8,6 +8,15 @@
          '[cljsjs.boot-cljsjs.packaging :refer :all])
 
 (def +version+ "2.13.1-0")
+
+(defn ->site-version
+  [boot-version]
+  (str "v" (clojure.string/join "." (drop 1 (re-find #"(\d+)\.(\d+)\.(\d+)\-.*" boot-version)))))
+
+(defn build-url
+  [boot-version]
+  (str "https://github.com/replit/jq-console/archive/" (->site-version boot-version) ".zip"))
+
 (bootlaces! +version+)
 
 (task-options!
@@ -20,13 +29,13 @@
 
 (deftask package []
   (comp
-   (download  :url      "https://github.com/replit/jq-console/zipball/master"
+   (download  :url      (build-url +version+)
               :unzip    true)
-   (sift      :move     {#"^replit-jq-console-(.*)/lib/jqconsole.js"
+   (sift      :move     {#"^jq-console-(.*)/lib/jqconsole.js"
                          "cljsjs/jqconsole/development/jqconsole.inc.js"
-                         #"^replit-jq-console-(.*)/jqconsole.min.js"
+                         #"^jq-console-(.*)/jqconsole.min.js"
                          "cljsjs/jqconsole/production/jqconsole.min.inc.js"
-                         #"^replit-jq-console-(.*)/css/ansi.css"
+                         #"^jq-console-(.*)/css/ansi.css"
                          "cljsjs/jqconsole/common/css/ansi.css"})
    (sift      :include  #{#"^cljsjs"})
    (deps-cljs :name     "cljsjs.jqconsole"

--- a/jqconsole/resources/cljsjs/jqconsole/common/jqconsole.ext.js
+++ b/jqconsole/resources/cljsjs/jqconsole/common/jqconsole.ext.js
@@ -1,0 +1,89 @@
+/**
+ * @fileoverview Closure Compiler externs for jqconsole.js 2.12.0
+ * @see http://replit.github.io/jq-console
+ * @externs
+ * @author Andrea Richiardi
+ */
+
+/**
+ * @constructor
+ * @param {(Element|jQuery|Document| Object.<string,
+ *     (string|function(!jQuery.event=))>)=} header Text to print at the top of
+ *     the console on reset. Optional. Defaults to an empty string.
+ * @param {?string|undefined} prompt_label The label to show
+ *     before the command prompt. Optional. Defaults to DEFAULT_PROMPT_LABEL.
+ * @param {?string|undefined} prompt_continue_label The label to
+ *     show before continuation lines of the command prompt. Optional. Defaults
+ *     to DEFAULT_PROMPT_CONINUE_LABEL.
+ * @param {?boolean|undefined} disable_auto_focus is a boolean indicating
+ *     whether we should disable the default auto-focus behavior.
+ * @return {!JQConsole}
+ */
+$.prototype.jqconsole = function(header, prompt_main, prompt_continue, disable_auto_focus) {};
+
+/**
+ * @constructor
+ * @param {(jQuerySelector|Element|Object|Array.<Element>|jQuery|string|
+ *     function())=} outer_container The DOM element into which the console is
+ *     inserted.
+ * @param {?string|undefined} header Text to print at the top of the console on
+ * reset. Optional. Defaults to an empty string.
+ * @param {?string|undefined} prompt_label The label to show
+ *     before the command prompt. Optional. Defaults to DEFAULT_PROMPT_LABEL.
+ * @param {?string|undefined} prompt_continue_label The label to
+ *     show before continuation lines of the command prompt. Optional. Defaults
+ *     to DEFAULT_PROMPT_CONINUE_LABEL.
+ * @param {?boolean|undefined} disable_auto_focus is a boolean indicating
+ *     whether we should disable the default auto-focus behavior.
+ * @return {!JQConsole}
+ */
+function JQConsole (outer_container, header, prompt_label, prompt_continue_label, disable_auto_focus) {}
+
+/**
+ * @constructor
+ * @return {!Ansi}
+ */
+function Ansi() {}
+
+/*------------------------ Shortcut Methods ----------------------------- */
+
+JQConsole.prototype.RegisterShortcut = function(key_code, callback) {};
+JQConsole.prototype.UnRegisterShortcut = function(key_code, handler) {};
+
+/*---------------------- END Shortcut Methods --------------------------- */
+
+/*------------------------ Public Methods ----------------------------- */
+
+JQConsole.prototype.ResetHistory = function() {};
+JQConsole.prototype.ResetShortcuts = function() {};
+JQConsole.prototype.ResetMatchings = function() {};
+JQConsole.prototype.Reset = function() {};
+JQConsole.prototype.GetHistory = function() {};
+JQConsole.prototype.SetHistory = function(history) {};
+JQConsole.prototype.GetColumn = function() {};
+JQConsole.prototype.GetLine = function() {};
+JQConsole.prototype.ClearPromptText = function(clear_label) {};
+JQConsole.prototype.GetPromptText = function(full) {};
+JQConsole.prototype.SetPromptText = function(text) {};
+JQConsole.prototype.SetPromptLabel = function(main_label, continue_label) {};
+JQConsole.prototype.UpdatePromptLabel = function() {};
+JQConsole.prototype.Write = function(text, cls, escape) {};
+JQConsole.prototype.Append = function(node) {};
+JQConsole.prototype.Input = function(input_callback) {};
+JQConsole.prototype.Prompt = function(history_enabled, result_callback, multiline_callback, async_multiline) {};
+JQConsole.prototype.AbortPrompt = function() {};
+JQConsole.prototype.Focus = function() {};
+JQConsole.prototype.SetIndentWidth = function(width) {};
+JQConsole.prototype.GetIndentWidth = function() {};
+JQConsole.prototype.RegisterMatching = function(open, close, cls) {};
+JQConsole.prototype.UnRegisterMatching = function(open, close) {};
+JQConsole.prototype.Dump = function() {};
+JQConsole.prototype.GetState = function() {};
+JQConsole.prototype.Disable = function() {};
+JQConsole.prototype.Enable = function() {};
+JQConsole.prototype.IsDisabled = function() {};
+JQConsole.prototype.MoveToStart = function(all_lines) {};
+JQConsole.prototype.MoveToEnd = function(all_lines) {};
+JQConsole.prototype.Clear = function() {};
+
+/*---------------------- END Public Methods --------------------------- */

--- a/jqconsole/resources/cljsjs/jqconsole/common/jqconsole.ext.js
+++ b/jqconsole/resources/cljsjs/jqconsole/common/jqconsole.ext.js
@@ -85,5 +85,7 @@ JQConsole.prototype.IsDisabled = function() {};
 JQConsole.prototype.MoveToStart = function(all_lines) {};
 JQConsole.prototype.MoveToEnd = function(all_lines) {};
 JQConsole.prototype.Clear = function() {};
+JQConsole.prototype.SetKeyPressHandler = function(handler) {};
+JQConsole.prototype.SetControlKeyHandler = function(handler) {};
 
 /*---------------------- END Public Methods --------------------------- */


### PR DESCRIPTION
This is a work in progress, because I am not a js expert.
I would like someone to double check as I can't make it work if ```:optimizations :advanced```.

Or better, it works if I manually import the dependencies with:
``` html 
<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
<script src="js/jqconsole/jqconsole.min.js"></script>
```

Otherwise it gives me the dreaded:
```Uncaught ReferenceError: $ is not defined```

P.S.:
``` [lein-cljsbuild "1.1.0"]```