### PR TITLE
fix .getDoc and move 2 methods to Doc Object

### DIFF
--- a/codemirror/README.md
+++ b/codemirror/README.md
@@ -2,7 +2,7 @@
 
 [](dependency)
 ```clojure
-[cljsjs/codemirror "5.7.0-1"] ;; latest release
+[cljsjs/codemirror "5.7.0-2"] ;; latest release
 ```
 [](/dependency)
 

--- a/codemirror/build.boot
+++ b/codemirror/build.boot
@@ -9,7 +9,7 @@
 (def codemirror-version "5.7.0")
 (def codemirror-checksum "0E203131B66E77DE9DCE32E13D56B812")
 
-(def +version+ (str codemirror-version "-1"))
+(def +version+ (str codemirror-version "-2"))
 
 (task-options!
   pom  {:project     'cljsjs/codemirror
@@ -67,4 +67,3 @@
                  #"^cljsjs/codemirror/common/keymap/(.*)\.js" "cljsjs/codemirror/common/keymap/$1.inc.js"
                  #"^cljsjs/codemirror/common/addon/(.*)/(.*)\.js" "cljsjs/codemirror/common/addon/$1/$2.inc.js"})
     (generate-extra-deps)))
-

--- a/codemirror/resources/cljsjs/codemirror/common/codemirror.ext.js
+++ b/codemirror/resources/cljsjs/codemirror/common/codemirror.ext.js
@@ -5,12 +5,17 @@ var CodeMirrorObj = function() {
 
 };
 
+/**
+ * Get the document object.
+ * @return {CodeMirrorDoc}
+ */
+CodeMirrorObj.prototype.getDoc = function(){};
 
 /**
- * Calculates and returns a {line, ch} object for a zero-based index who's value is relative to the start 
- * of the editor's text. If the index is out of range of the text then thereturned object is clipped to 
+ * Calculates and returns a {line, ch} object for a zero-based index who's value is relative to the start
+ * of the editor's text. If the index is out of range of the text then thereturned object is clipped to
  * start or end of the text respectively.
- */ 
+ */
 CodeMirrorObj.prototype.posFromIndex = function(off){};
 
 /**
@@ -238,21 +243,6 @@ CodeMirrorObj.prototype.setLine = function(n, text){};
  */
 CodeMirrorObj.prototype.removeLine = function(n){};
 /**
- * Get the text between the given points in the editor, which should be <code>{line, ch}</code> objects.
- * @param {{line:number, ch:number}} from
- * @param {{line:number, ch:number}} to
- */
-CodeMirrorObj.prototype.getRange = function(from, to){};
-/**
- * Replace the part of the document between <code>from</code> and <code>to</code> with the given string.
- * <code>from</code> and <code>to</code> must be <code>{line, ch}</code> objects. to can be left off to simply
- * insert the string at position from.
- * @param {string} str
- * @param {{line:number, ch:number}} from
- * @param {{line:number, ch:number}} to
- */
-CodeMirrorObj.prototype.replaceRange = function(str, from, to){};
-/**
  * Calculates and returns a <code>{line, ch}</code> object for a zero-based <code>index</code> who's value is relative
  * to the start of the editor's text. If the <code>index</code> is out of range of the text then the returned object is
  * clipped to start or end of the text respectively.
@@ -380,3 +370,24 @@ CodeMirror.fromTextArea = function(textAreaElement) {};
  * @param {*} value
  */
 CodeMirror.defineExtension = function(name, value){};
+
+/**
+ * @constructor
+ */
+var CodeMirrorDoc = function(){};
+
+/**
+ * Get the text between the given points in the editor, which should be <code>{line, ch}</code> objects.
+ * @param {{line:number, ch:number}} from
+ * @param {{line:number, ch:number}} to
+ */
+CodeMirrorDoc.prototype.getRange = function(from, to){};
+/**
+ * Replace the part of the document between <code>from</code> and <code>to</code> with the given string.
+ * <code>from</code> and <code>to</code> must be <code>{line, ch}</code> objects. to can be left off to simply
+ * insert the string at position from.
+ * @param {string} str
+ * @param {{line:number, ch:number}} from
+ * @param {{line:number, ch:number}} to
+ */
+CodeMirrorDoc.prototype.replaceRange = function(str, from, to){};


### PR DESCRIPTION
- most of the CM methods in this extern are incorrect, as they assume
they are methods on the CodeMirrorObj, when they are actually methods
on the CM Document Object
- added CodeMirrorDoc definition and redefined 2 of the methods
(getRange, replaceRange)
- Other methods still need doing properly

See CodeMirror API for further methods affected http://codemirror.net/doc/manual.html#api