### PR TITLE
[react-bootstrap] update deps to cljsjs.react 0.14.0-1 and fix a comment

### DIFF
--- a/react-bootstrap/README.md
+++ b/react-bootstrap/README.md
@@ -2,7 +2,7 @@
 
 [](dependency)
 ```clojure
-[cljsjs/react-bootstrap "0.25.2-0"] ;; latest release
+[cljsjs/react-bootstrap "0.27.3-0"] ;; latest release
 ```
 [](/dependency)
 
@@ -19,7 +19,7 @@ To use this with Boot require "boot-less" like so:
 ```clojure
 (set-env!
   :dependencies '[[deraen/boot-less "0.3.0" :scope "test"]
-                  [cljsjs/react-bootstrap "0.25.1-0"]])
+                  [cljsjs/react-bootstrap "0.27.3-0"]])
 
 ```
 create a "main.main.less" file within one of your source-paths with following content

--- a/react-bootstrap/build.boot
+++ b/react-bootstrap/build.boot
@@ -2,13 +2,13 @@
   :resource-paths #{"resources"}
   :dependencies '[[adzerk/bootlaces "0.1.11" :scope "test"]
                   [cljsjs/boot-cljsjs "0.5.0" :scope "test"]
-                  [cljsjs/react-with-addons "0.13.3-0"]
-                  [org.webjars.bower/bootstrap "3.3.4"]])
+                  [cljsjs/react-dom "0.14.0-0"]
+                  [org.webjars.bower/bootstrap "3.3.5"]])
 
 (require '[adzerk.bootlaces :refer :all]
          '[cljsjs.boot-cljsjs.packaging :refer :all])
 
-(def +version+ "0.25.2-0")
+(def +version+ "0.27.3-0")
 (bootlaces! +version+)
 
 (task-options!
@@ -20,8 +20,8 @@
        :license     {"MIT" "https://raw.githubusercontent.com/react-bootstrap/react-bootstrap/master/LICENSE"}})
 
 (deftask download-react-bootstrap []
-  (download :url      "https://github.com/react-bootstrap/react-bootstrap-bower/archive/v0.25.2.zip"
-            :checksum "F8B60FA1D9E489748E81F63BE4EE8DBB"
+  (download :url      "https://github.com/react-bootstrap/react-bootstrap-bower/archive/v0.27.3.zip"
+            :checksum "fe32b73aa12bd5d2cd920652933c873c"
             :unzip    true))
 
 (deftask package []
@@ -33,4 +33,4 @@
                  "cljsjs/react-bootstrap/production/react-bootstrap.min.inc.js"})
     (sift :include #{#"^cljsjs"})
     (deps-cljs :name "cljsjs.react-bootstrap"
-               :requires ["cljsjs.react"])))
+               :requires ["cljsjs.react.dom"])))

--- a/react-bootstrap/build.boot
+++ b/react-bootstrap/build.boot
@@ -2,7 +2,7 @@
   :resource-paths #{"resources"}
   :dependencies '[[adzerk/bootlaces "0.1.11" :scope "test"]
                   [cljsjs/boot-cljsjs "0.5.0" :scope "test"]
-                  [cljsjs/react-dom "0.14.0-0"]
+                  [cljsjs/react-dom "0.14.0-1"]
                   [org.webjars.bower/bootstrap "3.3.5"]])
 
 (require '[adzerk.bootlaces :refer :all]

--- a/react-bootstrap/resources/cljsjs/react-bootstrap/common/react-bootstrap.ext.js
+++ b/react-bootstrap/resources/cljsjs/react-bootstrap/common/react-bootstrap.ext.js
@@ -1,7 +1,7 @@
 // generated with http://www.dotnetwise.com/Code/Externs/
 // to regenerate from the tool:
 // first include https://fb.me/react-0.14.0.js
-// then https://cdnjs.cloudflare.com/ajax/libs/react-bootstrap/0.27.1/react-bootstrap.js
+// then https://cdnjs.cloudflare.com/ajax/libs/react-bootstrap/0.27.3/react-bootstrap.js
 // and enter ReactBootstrap as the javascript object to extern
 
 // see end for manual additions

--- a/react-bootstrap/resources/cljsjs/react-bootstrap/common/react-bootstrap.ext.js
+++ b/react-bootstrap/resources/cljsjs/react-bootstrap/common/react-bootstrap.ext.js
@@ -1,8 +1,10 @@
 // generated with http://www.dotnetwise.com/Code/Externs/
 // to regenerate from the tool:
-// first include http://fb.me/react-0.13.1.js
-// then https://cdnjs.cloudflare.com/ajax/libs/react-bootstrap/0.25.2/react-bootstrap.js
+// first include https://fb.me/react-0.14.0.js
+// then https://cdnjs.cloudflare.com/ajax/libs/react-bootstrap/0.27.1/react-bootstrap.js
 // and enter ReactBootstrap as the javascript object to extern
+
+// see end for manual additions
 
 var ReactBootstrap = {
     "__esModule": {},
@@ -33,6 +35,8 @@ var ReactBootstrap = {
         "getBsClassSet": function () {},
         "prefixClass": function () {}
     },
+    "Breadcrumb": function () {},
+    "BreadcrumbItem": function () {},
     "Button": function () {},
     "ButtonGroup": function () {},
     "ButtonInput": function () {},
@@ -40,41 +44,12 @@ var ReactBootstrap = {
     "Carousel": function () {},
     "CarouselItem": function () {},
     "Col": function () {},
-    "CollapsibleMixin": {
-        "propTypes": {
-            "defaultExpanded": function () {},
-            "expanded": function () {}
-        },
-        "getInitialState": function () {},
-        "componentWillMount": function () {},
-        "componentWillUpdate": function () {},
-        "componentDidUpdate": function () {},
-        "_afterWillUpdate": function () {},
-        "_checkStartAnimation": function () {},
-        "_checkToggleCollapsing": function () {},
-        "_handleExpand": function () {},
-        "_handleCollapse": function () {},
-        "_addEndEventListener": function () {},
-        "_removeEndEventListener": function () {},
-        "dimension": function () {},
-        "isExpanded": function () {},
-        "getCollapsibleClassSet": function () {}
-    },
     "CollapsibleNav": function () {},
     "Dropdown": function () {},
     "DropdownButton": function () {},
-    "NavDropdown": function () {},
-    "SplitButton": function () {},
-    "FadeMixin": {
-        "componentWillMount": function () {},
-        "_fadeIn": function () {},
-        "_fadeOut": function () {},
-        "_handleFadeOutEnd": function () {},
-        "componentDidMount": function () {},
-        "componentWillUnmount": function () {}
-    },
     "Glyphicon": function () {},
     "Grid": function () {},
+    "Image": function () {},
     "Input": function () {},
     "Interpolate": function () {},
     "Jumbotron": function () {},
@@ -83,12 +58,14 @@ var ReactBootstrap = {
     "ListGroupItem": function () {},
     "MenuItem": function () {},
     "Modal": function () {},
-    "ModalHeader": function () {},
-    "ModalTitle": function () {},
     "ModalBody": function () {},
     "ModalFooter": function () {},
+    "ModalHeader": function () {},
+    "ModalTitle": function () {},
     "Nav": function () {},
     "Navbar": function () {},
+    "NavBrand": function () {},
+    "NavDropdown": function () {},
     "NavItem": function () {},
     "Overlay": function () {},
     "OverlayTrigger": function () {},
@@ -100,8 +77,10 @@ var ReactBootstrap = {
     "PanelGroup": function () {},
     "Popover": function () {},
     "ProgressBar": function () {},
+    "ResponsiveEmbed": function () {},
     "Row": function () {},
     "SafeAnchor": function () {},
+    "SplitButton": function () {},
     "styleMaps": {
         "CLASSES": {
             "alert": {},
@@ -152,15 +131,11 @@ var ReactBootstrap = {
     },
     "SubNav": function () {},
     "Tab": function () {},
-    "TabbedArea": function () {},
     "Table": function () {},
-    "TabPane": function () {},
     "Tabs": function () {},
     "Thumbnail": function () {},
     "Tooltip": function () {},
     "Well": function () {},
-    "Portal": function () {},
-    "Position": function () {},
     "Collapse": function () {},
     "Fade": function () {},
     "FormControls": {
@@ -175,19 +150,23 @@ var ReactBootstrap = {
             "forEach": function () {},
             "numberOf": function () {},
             "find": function () {},
+            "findValidComponents": function () {},
             "hasValidComponent": function () {}
-        },
-        "CustomPropTypes": {
-            "deprecated": function () {},
-            "isRequiredForA11y": function () {},
-            "requiredRoles": function () {},
-            "exclusiveRoles": function () {},
-            "mountable": function () {},
-            "elementType": function () {},
-            "keyOf": function () {},
-            "singlePropFrom": function () {},
-            "all": function () {}
-        },
-        "domUtils": function () {}
+        }
     }
-};
+}
+
+// not picked up by the tool, so added by hand
+
+ReactBootstrap.Dropdown.Menu = function() {};
+ReactBootstrap.Dropdown.Toggle = function() {};
+
+ReactBootstrap.Input.getValue = function() {};
+
+ReactBootstrap.Modal.Body = function() {};
+ReactBootstrap.Modal.Dialog = function() {};
+ReactBootstrap.Modal.Footer = function() {};
+ReactBootstrap.Modal.Header = function() {};
+ReactBootstrap.Modal.Title = function() {};
+
+ReactBootstrap.SplitButton.Toggle = function() {};


### PR DESCRIPTION
This PR builds on a previous open PR, https://github.com/cljsjs/packages/pull/264, which is needed to be compatible with the version of React (0.14) that's currently in CLJSJS.