### PR TITLE
Update material to 1.0.6

### DIFF
--- a/material/README.md
+++ b/material/README.md
@@ -2,7 +2,7 @@
 
 [](dependency)
 ```clojure
-[cljsjs/material "1.0.5-0"] ;; latest release
+[cljsjs/material "1.0.6-0"] ;; latest release
 ```
 [](/dependency)
 

--- a/material/README.md
+++ b/material/README.md
@@ -2,7 +2,7 @@
 
 [](dependency)
 ```clojure
-[cljsjs/material "1.0.4-0"] ;; latest release
+[cljsjs/material "1.0.5-0"] ;; latest release
 ```
 [](/dependency)
 

--- a/material/build.boot
+++ b/material/build.boot
@@ -6,7 +6,7 @@
 (require '[adzerk.bootlaces :refer :all]
          '[cljsjs.boot-cljsjs.packaging :refer :all])
 
-(def material-version "1.0.5")
+(def material-version "1.0.6")
 (def +version+ (str material-version "-0"))
 (bootlaces! +version+)
 
@@ -22,7 +22,7 @@
   (task-options! push {:ensure-branch nil})
   (comp
     (download :url (str "https://github.com/google/material-design-lite/archive/v" material-version ".zip")
-              :checksum "f2016824b8dad95d015cf8dd5356187f"
+              :checksum "4869bf87ec07690f884dceeb51403c98"
               :unzip true)
     (sift :move {(re-pattern (str "^material-design-lite-" material-version "/material.js$"))        "cljsjs/material/development/material.inc.js"
                  (re-pattern (str "^material-design-lite-" material-version "/material.css$"))        "cljsjs/material/development/material.inc.css"

--- a/material/build.boot
+++ b/material/build.boot
@@ -6,7 +6,7 @@
 (require '[adzerk.bootlaces :refer :all]
          '[cljsjs.boot-cljsjs.packaging :refer :all])
 
-(def material-version "1.0.4")
+(def material-version "1.0.5")
 (def +version+ (str material-version "-0"))
 (bootlaces! +version+)
 
@@ -21,12 +21,12 @@
 (deftask package []
   (task-options! push {:ensure-branch nil})
   (comp
-    (download :url (str "https://storage.googleapis.com/code.getmdl.io/" material-version "/mdl.zip")
-              :checksum "e6883041f5cf44642b1539ecf5a25f9c"
+    (download :url (str "https://github.com/google/material-design-lite/archive/v" material-version ".zip")
+              :checksum "f2016824b8dad95d015cf8dd5356187f"
               :unzip true)
-    (sift :move {#"^material\.js$"        "cljsjs/material/development/material.inc.js"
-                 #"^material\.css$"        "cljsjs/material/development/material.inc.css"
-                 #"^material\.min\.js$"   "cljsjs/material/production/material.min.inc.js"
-                 #"^material\.min\.css$" "cljsjs/material/production/material.min.inc.css"})
+    (sift :move {(re-pattern (str "^material-design-lite-" material-version "/material.js$"))        "cljsjs/material/development/material.inc.js"
+                 (re-pattern (str "^material-design-lite-" material-version "/material.css$"))        "cljsjs/material/development/material.inc.css"
+                 (re-pattern (str "^material-design-lite-" material-version "/material.min.js$"))   "cljsjs/material/production/material.min.inc.js"
+                 (re-pattern (str "^material-design-lite-" material-version "/material.min.css$")) "cljsjs/material/production/material.min.inc.css"})
     (sift :include #{#"^cljsjs"})
     (deps-cljs :name "cljsjs.material")))


### PR DESCRIPTION
This updates material to the latest version.  It also moves it over to the github's releases, which have published checksums.