### PR TITLE
Update codemirror to 5.8.0

### DIFF
--- a/codemirror/README.md
+++ b/codemirror/README.md
@@ -2,7 +2,7 @@
 
 [](dependency)
 ```clojure
-[cljsjs/codemirror "5.7.0-3"] ;; latest release
+[cljsjs/codemirror "5.8.0-0"] ;; latest release
 ```
 [](/dependency)
 

--- a/codemirror/build.boot
+++ b/codemirror/build.boot
@@ -57,7 +57,8 @@
                  #"^CodeMirror-([\d\.]*)/mode/(.*)/\2\.js"      "cljsjs/codemirror/common/mode/$2.js"
                  #"^CodeMirror-([\d\.]*)/keymap/(.*)\.js"       "cljsjs/codemirror/common/keymap/$2.js"
                  #"^CodeMirror-([\d\.]*)/addon/(.*)/(.*)\.css"  "cljsjs/codemirror/common/addon/$2/$3.css"
-                 #"^CodeMirror-([\d\.]*)/addon/(.*)/(.*)\.js"   "cljsjs/codemirror/common/addon/$2/$3.js"})
+                 #"^CodeMirror-([\d\.]*)/addon/(.*)/(.*)\.js"   "cljsjs/codemirror/common/addon/$2/$3.js"
+                 #"^CodeMirror-([\d\.]*)/theme/(.*)\.css"       "cljsjs/codemirror/common/theme/$2.css"})
     (minify    :in       "cljsjs/codemirror/development/codemirror.inc.js"
                :out      "cljsjs/codemirror/production/codemirror.min.inc.js")
     (minify    :in       "cljsjs/codemirror/development/codemirror.css"

--- a/codemirror/build.boot
+++ b/codemirror/build.boot
@@ -6,10 +6,10 @@
 (require '[adzerk.bootlaces :refer :all]
          '[cljsjs.boot-cljsjs.packaging :refer :all])
 
-(def +lib-version+ "5.7.0")
-(def codemirror-checksum "0E203131B66E77DE9DCE32E13D56B812")
+(def +lib-version+ "5.8.0")
+(def codemirror-checksum "a0378a6bd7131f04246a40bb3ce00c19")
 
-(def +version+ (str +lib-version+ "-3"))
+(def +version+ (str +lib-version+ "-0"))
 
 (task-options!
   pom  {:project     'cljsjs/codemirror


### PR DESCRIPTION
In addition to the upgrade, also includes the previously missing `theme` directory's CSS files in the final jar.