### PR TITLE
snapsvg: add package version 0.4.1-0

### DIFF
--- a/snapsvg/README.md
+++ b/snapsvg/README.md
@@ -1,0 +1,18 @@
+# cljsjs/snapsvg
+
+[](dependency)
+```clojure
+[cljsjs/snapsvg "0.4.1-0"] ;; latest release
+```
+[](/dependency)
+
+This jar comes with `deps.cljs` as used by the [Foreign Libs][flibs] feature
+of the Clojurescript compiler. After adding the above dependency to your project
+you can require the packaged library like so:
+
+```clojure
+(ns application.core
+  (:require cljsjs.snapsvg))
+```
+
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies

--- a/snapsvg/build.boot
+++ b/snapsvg/build.boot
@@ -1,0 +1,33 @@
+(set-env!
+  :resource-paths #{"resources"}
+  :dependencies '[[adzerk/bootlaces   "0.1.10" :scope "test"]
+                  [cljsjs/boot-cljsjs "0.5.0"  :scope "test"]])
+
+(require '[adzerk.bootlaces :refer :all]
+         '[cljsjs.boot-cljsjs.packaging :refer :all])
+
+(def +version+ "0.4.1-0")
+(bootlaces! +version+)
+
+(task-options!
+ pom  {:project     'cljsjs/snapsvg
+       :version     +version+
+       :description "The JavaScript SVG library for the modern web"
+       :url         "https://snapsvg.io"
+       :scm         {:url "https://github.com/cljsjs/packages"}
+       :license     {"Apache-2.0" "http://opensource.org/licenses/Apache-2.0"}})
+
+(deftask download-snapsvg []
+  (download :url      "https://github.com/adobe-webplatform/Snap.svg/archive/v0.4.1.zip"
+            :checksum "faf20691a922b831fb6dce40e3ef4860"
+            :unzip    true))
+
+(deftask package []
+  (comp
+    (download-snapsvg)
+    (sift :move {#"^Snap.svg-.*/dist/snap.svg.js"
+                 "cljsjs/snapsvg/development/snapsvg.inc.js"
+                 #"^Snap.svg-.*/dist/snap.svg-min.js"
+                 "cljsjs/snapsvg/production/snapsvg.min.inc.js"})
+    (sift :include #{#"^cljsjs"})
+    (deps-cljs :name "cljsjs.snapsvg")))

--- a/snapsvg/resources/cljsjs/snapsvg/common/snapsvg.ext.js
+++ b/snapsvg/resources/cljsjs/snapsvg/common/snapsvg.ext.js
@@ -1,0 +1,182 @@
+var Snap = {
+  "version": {},
+  "toString": function () {},
+  "_": {
+    "glob": {
+      "win": {},
+      "doc": {}
+    },
+    "separator": {},
+    "$": function () {},
+    "id": function () {},
+    "clone": function () {},
+    "cacher": function () {},
+    "svgTransform2string": function () {},
+    "rgTransform": {},
+    "transform2matrix": function () {},
+    "getSomeDefs": function () {},
+    "getSomeSVG": function () {},
+    "make": function () {},
+    "wrap": function () {},
+    "Animation": function () {},
+    "box": function () {}
+  },
+  "url": function () {},
+  "format": function () {},
+  "rad": function () {},
+  "deg": function () {},
+  "sin": function () {},
+  "tan": function () {},
+  "cos": function () {},
+  "asin": function () {},
+  "acos": function () {},
+  "atan": function () {},
+  "atan2": function () {},
+  "angle": function () {},
+  "len": function () {},
+  "len2": function () {},
+  "closestPoint": function () {},
+  "is": function () {},
+  "snapTo": function () {},
+  "getRGB": function () {},
+  "hsb": function () {},
+  "hsl": function () {},
+  "rgb": function () {},
+  "color": function () {},
+  "hsb2rgb": function () {},
+  "hsl2rgb": function () {},
+  "rgb2hsb": function () {},
+  "rgb2hsl": function () {},
+  "parsePathString": function () {},
+  "parseTransformString": function () {},
+  "_unit2px": function () {},
+  "select": function () {},
+  "selectAll": function () {},
+  "parse": function () {},
+  "fragment": function () {},
+  "ajax": function () {},
+  "load": function () {},
+  "getElementByPoint": function () {},
+  "plugin": function () {},
+  "animation": function () {},
+  "animate": function () {},
+  "Matrix": function () {},
+  "matrix": function () {},
+  "path": {
+    "getTotalLength": function () {},
+    "getPointAtLength": function () {},
+    "getSubpath": function () {},
+    "findDotsAtSegment": function () {},
+    "bezierBBox": function () {},
+    "isPointInsideBBox": function () {},
+    "isBBoxIntersect": function () {},
+    "intersection": function () {},
+    "intersectionNumber": function () {},
+    "isPointInside": function () {},
+    "getBBox": function () {},
+    "get": {
+      "path": function () {},
+      "circle": function () {},
+      "ellipse": function () {},
+      "rect": function () {},
+      "image": function () {},
+      "line": function () {},
+      "polyline": function () {},
+      "polygon": function () {},
+      "deflt": function () {}
+    },
+    "toRelative": function () {},
+    "toAbsolute": function () {},
+    "toCubic": function () {},
+    "map": function () {},
+    "toString": function () {},
+    "clone": function () {}
+  },
+  "closest": function () {},
+  "Set": function () {},
+  "set": function () {},
+  "touchcancel": function () {},
+  "untouchcancel": function () {},
+  "touchend": function () {},
+  "untouchend": function () {},
+  "touchmove": function () {},
+  "untouchmove": function () {},
+  "touchstart": function () {},
+  "untouchstart": function () {},
+  "mouseup": function () {},
+  "unmouseup": function () {},
+  "mouseover": function () {},
+  "unmouseover": function () {},
+  "mouseout": function () {},
+  "unmouseout": function () {},
+  "mousemove": function () {},
+  "unmousemove": function () {},
+  "mousedown": function () {},
+  "unmousedown": function () {},
+  "dblclick": function () {},
+  "undblclick": function () {},
+  "click": function () {},
+  "unclick": function () {},
+  "filter": {
+    "blur": {
+      "toString": function () {}
+    },
+    "shadow": {
+      "toString": function () {}
+    },
+    "grayscale": {
+      "toString": function () {}
+    },
+    "sepia": {
+      "toString": function () {}
+    },
+    "saturate": {
+      "toString": function () {}
+    },
+    "hueRotate": {
+      "toString": function () {}
+    },
+    "invert": {
+      "toString": function () {}
+    },
+    "brightness": {
+      "toString": function () {}
+    },
+    "contrast": {
+      "toString": function () {}
+    }
+  }
+};
+Snap.Matrix.prototype = {
+  "add": function () {},
+  "invert": function () {},
+  "clone": function () {},
+  "translate": function () {},
+  "scale": function () {},
+  "rotate": function () {},
+  "x": function () {},
+  "y": function () {},
+  "get": function () {},
+  "toString": function () {},
+  "offset": function () {},
+  "determinant": function () {},
+  "split": function () {},
+  "toTransformString": function () {}
+};
+Snap.Set.prototype = {
+  "push": function () {},
+  "pop": function () {},
+  "forEach": function () {},
+  "animate": function () {},
+  "remove": function () {},
+  "bind": function () {},
+  "attr": function () {},
+  "clear": function () {},
+  "splice": function () {},
+  "exclude": function () {},
+  "insertAfter": function () {},
+  "getBBox": function () {},
+  "clone": function () {},
+  "toString": function () {},
+  "type": function () {}
+};


### PR DESCRIPTION
This PR adds a CLJSJS package for [Snap.svg](http://snapsvg.io/).

I ported one of their demos to ClojureScript and the result can be found [here](http://diegonc.github.io/tests/snapsvg/clock/dist/public/). You can clone/browse my [`diegonc.github.io`](https://github.com/diegonc/diegonc.github.io) repository to look at the sources (sorry for the code style, it's not very functional).

It's a dependency of [react-burger-menu](https://github.com/negomi/react-burger-menu) for which I also have a branch and will make a pull request if Snap is merged.