### PR TITLE
react-burger-menu: add version 1.1.6-0

### DIFF
--- a/react-burger-menu/README.md
+++ b/react-burger-menu/README.md
@@ -1,0 +1,18 @@
+# cljsjs/react-burger-menu
+
+[](dependency)
+```clojure
+[cljsjs/react-burger-menu "1.1.6-0"] ;; latest release
+```
+[](/dependency)
+
+This jar comes with `deps.cljs` as used by the [Foreign Libs][flibs] feature
+of the Clojurescript compiler. After adding the above dependency to your project
+you can require the packaged library like so:
+
+```clojure
+(ns application.core
+  (:require cljsjs.react-burger-menu))
+```
+
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies

--- a/react-burger-menu/build.boot
+++ b/react-burger-menu/build.boot
@@ -1,0 +1,37 @@
+(set-env!
+  :resource-paths #{"resources"}
+  :dependencies '[[adzerk/bootlaces   "0.1.10" :scope "test"]
+                  [cljsjs/boot-cljsjs "0.5.0"  :scope "test"]
+                  [cljsjs/react       "0.13.3-0"]
+                  [cljsjs/snapsvg     "0.4.1-0"]])
+
+(require '[adzerk.bootlaces :refer :all]
+         '[cljsjs.boot-cljsjs.packaging :refer :all])
+
+(def +lib-version+ "1.1.6")
+(def +version+ (str +lib-version+ "-0"))
+(bootlaces! +version+)
+
+(task-options!
+ pom  {:project     'cljsjs/react-burger-menu
+       :version     +version+
+       :description "An off-canvas sidebar component with a collection of effects and styles using CSS transitions and SVG path animations"
+       :url         "https://github.com/negomi/react-burger-menu"
+       :scm         {:url "https://github.com/cljsjs/packages"}
+       :license     {"MIT" "http://opensource.org/licenses/MIT"}})
+
+(deftask download-react-burger-menu []
+  (download :url      (str "https://github.com/negomi/react-burger-menu/archive/" +lib-version+ ".zip")
+            :checksum "a113cce4af93dc0c18034b9589b38ccc"
+            :unzip    true))
+
+(deftask package []
+  (comp
+    (download-react-burger-menu)
+    (sift :move {#"^react-.*/dist/react-burger-menu.js"
+                 "cljsjs/react-burger-menu/development/react-burger-menu.inc.js"
+                 #"^react-.*/dist/react-burger-menu.min.js"
+                 "cljsjs/react-burger-menu/production/react-burger-menu.min.inc.js"})
+    (sift :include #{#"^cljsjs"})
+    (deps-cljs :name "cljsjs.react-burger-menu"
+               :requires ["cljsjs.react" "cljsjs.snapsvg"])))

--- a/react-burger-menu/resources/cljsjs/react-burger-menu/common/react-burger-menu.ext.js
+++ b/react-burger-menu/resources/cljsjs/react-burger-menu/common/react-burger-menu.ext.js
@@ -1,0 +1,11 @@
+var BurgerMenu = {
+    "slide": function () {},
+    "stack": function () {},
+    "elastic": function () {},
+    "bubble": function () {},
+    "push": function () {},
+    "pushRotate": function () {},
+    "scaleDown": function () {},
+    "scaleRotate": function () {},
+    "fallDown": function () {}
+}


### PR DESCRIPTION
This is the React component [react-burger-menu](http://negomi.github.io/react-burger-menu/) packaged for ClojureScript.

I generated the externs using one of the online tool and the upstream provided example, after being ported to cljs, still [works](http://diegonc.github.io/tests/react-burger-menu/om-example/dist/public/).

Note that the zip is downloaded from **branch 1.1.6** because I found some [errors](https://github.com/negomi/react-burger-menu/issues/23) in the distributed files and the author fixed it in that branch.
So, while tag _v1.1.6_ exists, it's broken and should not be used to download the zip file.