### PR TITLE
[mathbox] Create MathBox package

### DIFF
--- a/mathbox/README.md
+++ b/mathbox/README.md
@@ -1,0 +1,22 @@
+# cljsjs/mathbox
+
+[](dependency)
+```clojure
+[cljsjs/mathbox "0.0.1-0"] ;; latest release
+```
+[](/dependency)
+
+ClojureScript package for the [MathBox](mathbox) mathematical visualization library. Note that this is MathBox 1, not the very different [MathBox 2](mathbox2) library by the same author, which is in alpha release as of this writing. Author is also preparing a cljs-mathbox library for Clojars, which is an idiomatic(ish) cljs wrapper for MathBox.
+
+This jar comes with `deps.cljs` as used by the [Foreign Libs][flibs] feature
+of the Clojurescript compiler. After adding the above dependency to your project
+you can require the packaged library like so:
+
+```clojure
+(ns application.core
+  (:require cljsjs.mathbox))
+```
+
+[mathbox]: https://github.com/unconed/MathBox.js/tree/legacy
+[mathbox2]: https://gitgud.io/unconed/mathbox
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies

--- a/mathbox/build.boot
+++ b/mathbox/build.boot
@@ -5,7 +5,8 @@
 (require '[adzerk.bootlaces :refer :all]
          '[cljsjs.boot-cljsjs.packaging :refer :all])
 
-(def +version+ "0.0.1-0") ; MathBox 1, *not* MathBox 2
+(def +lib-version+ "0.0.1") ; MathBox 1, *not* MathBox 2
+(def +version+ (str +lib-version+ "-0"))
 
 (task-options!
  pom {:project 'cljsjs/mathbox

--- a/mathbox/build.boot
+++ b/mathbox/build.boot
@@ -1,0 +1,28 @@
+(set-env!
+ :resource-paths #{"resources"}
+ :dependencies '[[adzerk/bootlaces   "0.1.9" :scope "test"]
+                 [cljsjs/boot-cljsjs "0.5.0" :scope "test"]])
+(require '[adzerk.bootlaces :refer :all]
+         '[cljsjs.boot-cljsjs.packaging :refer :all])
+
+(def +version+ "0.0.1-0") ; MathBox 1, *not* MathBox 2
+
+(task-options!
+ pom {:project 'cljsjs/mathbox
+      :version +version+
+      :description "MathBox 1: Three-dimensional, animated mathematical visualization"
+      :url "https://github.com/unconed/MathBox.js/tree/legacy"
+      :license {"MIT" "http://opensource.org/licenses/MIT"}
+      :scm {:url "https://github.com/cljsjs/packages"}})
+
+;; Download URLs are pinned to MathBox commit dd80272 to ensure no possible
+;; breakage, since versioning is quite informal for MathBox 1.
+(deftask package []
+  (comp
+   (download :url "https://github.com/unconed/MathBox.js/blob/dd802725b51260dcb361c65387afbb2a1e99b3ea/build/MathBox-bundle.js?raw=true"
+             :name "cljsjs/mathbox/development/MathBox-bundle.inc.js"
+             :checksum "1788279CD9C9CBECD68834E428E53E79")
+   (download :url "https://raw.githubusercontent.com/unconed/MathBox.js/dd802725b51260dcb361c65387afbb2a1e99b3ea/build/MathBox-bundle.min.js"
+             :name "cljsjs/mathbox/production/MathBox-bundle.min.inc.js"
+             :checksum "9BEA602B731DEF836963EDB1D35F4D4C")
+   (deps-cljs :name "cljsjs.mathbox")))

--- a/mathbox/resources/cljsjs/mathbox/common/mathbox.ext.js
+++ b/mathbox/resources/cljsjs/mathbox/common/mathbox.ext.js
@@ -1,13 +1,9 @@
-
-// definitely global:
-// getElementById
-
 var ThreeBox = {};
 ThreeBox.preload = function(element, options) {};
 
-var MathBox = {};
-// var mathBox = function(element, options);
 var window.mathBox = function(element, options);
+
+var MathBox = {};
 MathBox.start = function() {};
 MathBox.platonic = function(options) {};
 MathBox.curve = function(options) {};
@@ -22,6 +18,5 @@ MathBox.animate = function(object, attributes, options) {};
 MathBox.clone = function(selector, options, animate) {};
 MathBox.vector = function(options) {};
 MathBox.remove = function() {};
-
 MathBox.get = function(selector) {};
 MathBox.set = function(selector, options) {};

--- a/mathbox/resources/cljsjs/mathbox/common/mathbox.ext.js
+++ b/mathbox/resources/cljsjs/mathbox/common/mathbox.ext.js
@@ -1,0 +1,27 @@
+
+// definitely global:
+// getElementById
+
+var ThreeBox = {};
+ThreeBox.preload = function(element, options) {};
+
+var MathBox = {};
+// var mathBox = function(element, options);
+var window.mathBox = function(element, options);
+MathBox.start = function() {};
+MathBox.platonic = function(options) {};
+MathBox.curve = function(options) {};
+MathBox.bezier = function(options) {};
+MathBox.bezierSurface = function(options) {};
+MathBox.grid = function(options) {};
+MathBox.axis = function(options) {};
+MathBox.surface = function(options) {};
+MathBox.viewport = function(options) {};
+MathBox.camera = function(options) {};
+MathBox.animate = function(object, attributes, options) {};
+MathBox.clone = function(selector, options, animate) {};
+MathBox.vector = function(options) {};
+MathBox.remove = function() {};
+
+MathBox.get = function(selector) {};
+MathBox.set = function(selector, options) {};


### PR DESCRIPTION
By request from a couple of people in the cljs community, with the blessing of the MathBox author, and in preparation for putting a cljs wrapper for it onto Clojars, I've added a [MathBox](https://github.com/unconed/MathBox.js/tree/legacy) package.

This is my first time using boot (and my first contribution to CLJSJS), so feedback and critique would be much appreciated if anyone has any.