### PR TITLE
New package for spin.js

### DIFF
--- a/spin/README.md
+++ b/spin/README.md
@@ -1,0 +1,22 @@
+# cljsjs/three
+
+[](dependency)
+```clojure
+[cljsjs/spin "2.3.2"] ;; latest release
+```
+[](/dependency)
+
+ClojureScript package for the [spin.js](spin.js) utility for creating animated
+progress spinners.
+
+This jar comes with `deps.cljs` as used by the [Foreign Libs][flibs] feature
+of the Clojurescript compiler. After adding the above dependency to your project
+you can require the packaged library like so:
+
+```clojure
+(ns application.core
+  (:require cljsjs.spin))
+```
+
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies
+[spin.js]: http://spin.js.org

--- a/spin/build.boot
+++ b/spin/build.boot
@@ -1,0 +1,28 @@
+(set-env!
+ :resource-paths #{"resources"}
+ :dependencies '[[adzerk/bootlaces   "0.1.10" :scope "test"]
+                 [cljsjs/boot-cljsjs "0.5.0"  :scope "test"]])
+
+(require '[adzerk.bootlaces :refer :all]
+         '[cljsjs.boot-cljsjs.packaging :refer :all])
+
+(def +version+ "2.3.2")
+(bootlaces! +version+)
+
+(task-options!
+ pom {:project     'cljsjs/spin
+      :version     +version+
+      :description "A spinning activity indicator"
+      :url         "http://spin.js.org"
+      :scm         {:url "https://github.com/fgnass/spin.js"}
+      :license     {"MIT" "http://opensource.org/licenses/MIT"}})
+
+(deftask package []
+  (comp
+    (download :url "https://github.com/fgnass/spin.js/archive/2.3.2.zip"
+              :checksum "71a0e4985a2711589f2e5eecfec3e416"
+              :unzip true)
+    (sift :move {#"^spin\.js-2\.3\.2/spin\.js" "cljsjs/spin/development/spin.inc.js"
+                 #"^spin\.js-2\.3\.2/spin\.min\.js" "cljsjs/spin/production/spin.min.inc.js"})
+    (sift :include #{#"^cljsjs"})
+    (deps-cljs :name "cljsjs.spin")))

--- a/spin/resources/cljsjs/spin/common/spin.ext.js
+++ b/spin/resources/cljsjs/spin/common/spin.ext.js
@@ -1,0 +1,4 @@
+/** @interface */
+function Spinner(opts) {}
+Spinner.prototype.spin = function(target) {};
+Spinner.prototype.stop = function() {};


### PR DESCRIPTION
Added a package for spin.js, which is a simple utility for creating progress spinners. Tested locally. Have not contributed any cljsjs packages before, but followed the "Creating Packages" walkthrough. Hopefully everything is ok.