### PR TITLE
Mention actual latest version in README

### DIFF
--- a/jquery/README.md
+++ b/jquery/README.md
@@ -2,7 +2,8 @@
 
 [](dependency)
 ```clojure
-[cljsjs/jquery "1.9.1-0"] ;; latest release
+[cljsjs/jquery "1.11.3-0"] ;; latest 1.* release
+[cljsjs/jquery "2.1.4-0"]  ;; latest 2.* release
 ```
 [](/dependency)
 


### PR DESCRIPTION
Due to the way this is packaged, the `[](dependecy)` section has not been automatically updated.