### PR TITLE
Add react-dom as dependency for react-select

### DIFF
--- a/react-select/build.boot
+++ b/react-select/build.boot
@@ -1,7 +1,7 @@
 (set-env!
   :resource-paths #{"resources"}
   :dependencies '[[cljsjs/boot-cljsjs "0.5.0"  :scope "test"]
-		  [cljsjs/react "0.14.3-0"]
+                  [cljsjs/react "0.14.3-0"]
                   [cljsjs/classnames "2.1.3-0"]
                   [cljsjs/react-input-autosize "0.6.5-0"]])
 
@@ -11,12 +11,12 @@
 (def +version+ (str +lib-version+ "-0"))
 
 (task-options!
- pom  {:project     'cljsjs/react-select
-       :version     +version+
-       :description "A flexible and beautiful Select Input control for ReactJS with multiselect, autocomplete and ajax support."
-       :url         "http://jedwatson.github.io/react-select/"
-       :scm         {:url "https://github.com/cljsjs/packages"}
-       :license     {"MIT" "http://opensource.org/licenses/MIT"}})
+  pom  {:project     'cljsjs/react-select
+        :version     +version+
+        :description "A flexible and beautiful Select Input control for ReactJS with multiselect, autocomplete and ajax support."
+        :url         "http://jedwatson.github.io/react-select/"
+        :scm         {:url "https://github.com/cljsjs/packages"}
+        :license     {"MIT" "http://opensource.org/licenses/MIT"}})
 
 (require '[boot.core :as c]
          '[boot.tmpdir :as tmpd]
@@ -26,12 +26,12 @@
 (deftask package []
   (comp
     (download :url (str "https://github.com/JedWatson/react-select/archive/v" +lib-version+ ".zip")
-	      :checksum "7DBDA8770F221E881ADE123C72F05279"	
+              :checksum "7DBDA8770F221E881ADE123C72F05279"
               :unzip true)
 
     (sift :move {#"^react-select.*[/ \\]dist[/ \\]react-select.js$" "cljsjs/react-select/development/react-select.inc.js"
-	         #"^react-select.*[/ \\]dist[/ \\]react-select.min\.js$" "cljsjs/react-select/production/react-select.min.inc.js"
-	         #"^react-select.*[/ \\]dist[/ \\]react-select.css$" "cljsjs/react-select/common/react-select.inc.css"})
+                 #"^react-select.*[/ \\]dist[/ \\]react-select.min\.js$" "cljsjs/react-select/production/react-select.min.inc.js"
+                 #"^react-select.*[/ \\]dist[/ \\]react-select.css$" "cljsjs/react-select/common/react-select.inc.css"})
 
     (sift :include #{#"^cljsjs"})
 

--- a/react-select/build.boot
+++ b/react-select/build.boot
@@ -2,13 +2,14 @@
   :resource-paths #{"resources"}
   :dependencies '[[cljsjs/boot-cljsjs "0.5.0"  :scope "test"]
                   [cljsjs/react "0.14.3-0"]
+                  [cljsjs/react-dom "0.14.3-1"]
                   [cljsjs/classnames "2.1.3-0"]
                   [cljsjs/react-input-autosize "0.6.5-0"]])
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
 (def +lib-version+ "1.0.0-beta6")
-(def +version+ (str +lib-version+ "-0"))
+(def +version+ (str +lib-version+ "-1"))
 
 (task-options!
   pom  {:project     'cljsjs/react-select
@@ -37,5 +38,6 @@
 
     (deps-cljs :name "cljsjs.react-select"
                :requires ["cljsjs.react"
+                          "cljsjs.react.dom"
                           "cljsjs.classnames"
                           "cljsjs.react-input-autosize"])))


### PR DESCRIPTION
What is says on the tin. Without this dependency you get `Uncaught TypeError: Cannot read property 'findDOMNode' of undefined` when navigating the select box with the arrow keys, which leads to broken scrolling.

I haven't tested this locally, since `boot package build-jar` fails with

```
➜  react-select git:(react-select-dom) boot package build-jar
             clojure.lang.ExceptionInfo: java.lang.IllegalArgumentException: No such task (build-jar)
    data: {:file
           "/var/folders/t2/bmq0l4f516789351wk6b_sgh0000gn/T/boot.user3216260690496726718.clj",
           :line 21}
java.util.concurrent.ExecutionException: java.lang.IllegalArgumentException: No such task (build-jar)
     java.lang.IllegalArgumentException: No such task (build-jar)
          boot.core/construct-tasks  core.clj:  754
                                ...
                 clojure.core/apply  core.clj:  630
                  boot.core/boot/fn  core.clj:  802
clojure.core/binding-conveyor-fn/fn  core.clj: 1916
                                ...
```

Any clue as to why this doesn't work?