### PR TITLE
Add methods clearLayers and addData to leaflet externs

### DIFF
--- a/leaflet/resources/cljsjs/common/leaflet.ext.js
+++ b/leaflet/resources/cljsjs/common/leaflet.ext.js
@@ -676,6 +676,7 @@ var L = {
   "LayerGroup": function () {},
   "layerGroup": {
     "addLayer": function () {},
+    "clearLayers": function () {},
    },
   "FeatureGroup": function () {},
   "featureGroup": function () {},
@@ -711,7 +712,9 @@ var L = {
   "CircleMarker": function () {},
   "circleMarker": function () {},
   "GeoJSON": function () {},
-  "geoJson": function () {},
+  "geoJson": {
+    "addData": function () {}
+  },
   "DomEvent": {
     "addListener": function () {},
     "removeListener": function () {},


### PR DESCRIPTION
This PR adds missing [clearLayers](http://leafletjs.com/reference.html#layergroup-clearlayers) and [addData](http://leafletjs.com/reference.html#geojson-adddata) to leaflet externs file