### PR TITLE
[react-bootstrap] Update to v0.28.1

### DIFF
--- a/react-bootstrap/README.md
+++ b/react-bootstrap/README.md
@@ -2,7 +2,7 @@
 
 [](dependency)
 ```clojure
-[cljsjs/react-bootstrap "0.27.3-0"] ;; latest release
+[cljsjs/react-bootstrap "0.28.1-0"] ;; latest release
 ```
 [](/dependency)
 
@@ -19,7 +19,7 @@ To use this with Boot require "boot-less" like so:
 ```clojure
 (set-env!
   :dependencies '[[deraen/boot-less "0.3.0" :scope "test"]
-                  [cljsjs/react-bootstrap "0.27.3-0"]])
+                  [cljsjs/react-bootstrap "0.28.1-0"]])
 
 ```
 create a "main.main.less" file within one of your source-paths with following content

--- a/react-bootstrap/build.boot
+++ b/react-bootstrap/build.boot
@@ -1,12 +1,13 @@
 (set-env!
   :resource-paths #{"resources"}
   :dependencies '[[cljsjs/boot-cljsjs "0.5.0" :scope "test"]
-                  [cljsjs/react-dom "0.14.0-1"]
-                  [org.webjars.bower/bootstrap "3.3.5"]])
+                  [cljsjs/react-dom "0.14.3-1"]
+                  [org.webjars.bower/bootstrap "3.3.6"]])
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
-(def +version+ "0.27.3-0")
+(def +lib-version+ "0.28.1")
+(def +version+ (str +lib-version+ "-0"))
 
 (task-options!
  pom  {:project     'cljsjs/react-bootstrap
@@ -17,8 +18,8 @@
        :license     {"MIT" "https://raw.githubusercontent.com/react-bootstrap/react-bootstrap/master/LICENSE"}})
 
 (deftask download-react-bootstrap []
-  (download :url      "https://github.com/react-bootstrap/react-bootstrap-bower/archive/v0.27.3.zip"
-            :checksum "fe32b73aa12bd5d2cd920652933c873c"
+  (download :url      "https://github.com/react-bootstrap/react-bootstrap-bower/archive/v0.28.1.zip"
+            :checksum "a9df3496eee7df123e22cb409509551a"
             :unzip    true))
 
 (deftask package []

--- a/react-bootstrap/resources/cljsjs/react-bootstrap/common/react-bootstrap.ext.js
+++ b/react-bootstrap/resources/cljsjs/react-bootstrap/common/react-bootstrap.ext.js
@@ -1,7 +1,7 @@
 // generated with http://www.dotnetwise.com/Code/Externs/
 // to regenerate from the tool:
-// first include https://fb.me/react-0.14.0.js
-// then https://cdnjs.cloudflare.com/ajax/libs/react-bootstrap/0.27.3/react-bootstrap.js
+// first include https://fb.me/react-0.14.3.js
+// then https://cdnjs.cloudflare.com/ajax/libs/react-bootstrap/0.28.1/react-bootstrap.js
 // and enter ReactBootstrap as the javascript object to extern
 
 // see end for manual additions
@@ -9,32 +9,8 @@
 var ReactBootstrap = {
     "__esModule": {},
     "Accordion": function () {},
-    "Affix": function () {},
-    "AffixMixin": {
-        "propTypes": {
-            "offset": function () {},
-            "offsetTop": function () {},
-            "offsetBottom": function () {}
-        },
-        "getInitialState": function () {},
-        "getPinnedOffset": function () {},
-        "checkPosition": function () {},
-        "checkPositionWithEventLoop": function () {},
-        "componentDidMount": function () {},
-        "componentWillUnmount": function () {},
-        "componentDidUpdate": function () {}
-    },
     "Alert": function () {},
     "Badge": function () {},
-    "BootstrapMixin": {
-        "propTypes": {
-            "bsClass": function () {},
-            "bsStyle": function () {},
-            "bsSize": function () {}
-        },
-        "getBsClassSet": function () {},
-        "prefixClass": function () {}
-    },
     "Breadcrumb": function () {},
     "BreadcrumbItem": function () {},
     "Button": function () {},
@@ -65,6 +41,7 @@ var ReactBootstrap = {
     "Nav": function () {},
     "Navbar": function () {},
     "NavBrand": function () {},
+    "NavbarBrand": function () {},
     "NavDropdown": function () {},
     "NavItem": function () {},
     "Overlay": function () {},
@@ -81,55 +58,6 @@ var ReactBootstrap = {
     "Row": function () {},
     "SafeAnchor": function () {},
     "SplitButton": function () {},
-    "styleMaps": {
-        "CLASSES": {
-            "alert": {},
-            "button": {},
-            "button-group": {},
-            "button-toolbar": {},
-            "column": {},
-            "input-group": {},
-            "form": {},
-            "glyphicon": {},
-            "label": {},
-            "thumbnail": {},
-            "list-group-item": {},
-            "panel": {},
-            "panel-group": {},
-            "pagination": {},
-            "progress-bar": {},
-            "nav": {},
-            "navbar": {},
-            "modal": {},
-            "row": {},
-            "well": {}
-        },
-        "STYLES": {
-            "0": {},
-            "1": {},
-            "2": {},
-            "3": {},
-            "4": {},
-            "5": {},
-            "6": {},
-            "7": {},
-            "8": {},
-            "9": {}
-        },
-        "addStyle": function () {},
-        "SIZES": {
-            "large": {},
-            "medium": {},
-            "small": {},
-            "xsmall": {},
-            "lg": {},
-            "md": {},
-            "sm": {},
-            "xs": {}
-        },
-        "GRID_COLUMNS": {}
-    },
-    "SubNav": function () {},
     "Tab": function () {},
     "Table": function () {},
     "Tabs": function () {},
@@ -143,6 +71,11 @@ var ReactBootstrap = {
         "Static": function () {}
     },
     "utils": {
+        "bootstrapUtils": {
+            "prefix": function () {},
+            "getClassSet": function () {},
+            "addStyle": function () {}
+        },
         "childrenValueInputValidation": function () {},
         "createChainedFunction": function () {},
         "ValidComponentChildren": {
@@ -161,6 +94,8 @@ var ReactBootstrap = {
 ReactBootstrap.Dropdown.Menu = function() {};
 ReactBootstrap.Dropdown.Toggle = function() {};
 
+ReactBootstrap.Input.getChecked = function() {};
+ReactBootstrap.Input.getInputDOMNode = function() {};
 ReactBootstrap.Input.getValue = function() {};
 
 ReactBootstrap.Modal.Body = function() {};


### PR DESCRIPTION
Just keeping this up-to-date.  This patch updates to the latest bootstrap and react-bootstrap, using the latest cljsjs/react-dom dependency.  Changes to externs reflect some reorganization in the upstream project primarily related to navbar components.
