### PR TITLE
Fix quill externs issues

### DIFF
--- a/quill/build.boot
+++ b/quill/build.boot
@@ -4,7 +4,7 @@
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
-(def +version+ "0.20.0-0")
+(def +version+ "0.20.0-1")
 
 (task-options!
   pom {:project     'cljsjs/quill

--- a/quill/resources/cljsjs/quill/common/quill.ext.js
+++ b/quill/resources/cljsjs/quill/common/quill.ext.js
@@ -1,32 +1,19 @@
-Quill = function(elem) {};
-Quill = function(elem, configs) {};
+function Quill(elem, configs) {};
 
-Quill.prototype.getText = function() {};
-Quill.prototype.getText = function(start) {};
 Quill.prototype.getText = function(start, end) {};
 
 Quill.prototype.getLength = function() {};
 
-Quill.prototype.getContents = function() {};
-Quill.prototype.getContents = function(start) {};
 Quill.prototype.getContents = function(start, end) {};
 
 Quill.prototype.getHTML = function() {};
 
-Quill.prototype.insertText = function(index, text) {};
-Quill.prototype.insertText = function(index, text, name, value) {};
-Quill.prototype.insertText = function(index, text, source) {};
 Quill.prototype.insertText = function(index, text, name, value, source) {};
-Quill.prototype.insertText = function(index, text, formats, source) {};
 
-Quill.prototype.deleteText = function(start, end) {};
 Quill.prototype.deleteText = function(start, end, source) {};
 
-Quill.prototype.formatText = function(start, end) {};
 Quill.prototype.formatText = function(start, end, name, value) {};
-Quill.prototype.formatText = function(start, end, formats) {};
 
-Quill.prototype.insertEmbed = function(index, type, url) {};
 Quill.prototype.insertEmbed = function(index, type, url, source) {};
 
 Quill.prototype.updateContents = function(delta) {};
@@ -39,9 +26,7 @@ Quill.prototype.setText = function(text) {};
 
 Quill.prototype.getSelection = function() {};
 
-Quill.prototype.setSelection = function(start, end) {};
 Quill.prototype.setSelection = function(start, end, source) {};
-Quill.prototype.setSelection = function(range) {};
 
 Quill.prototype.prepareFormat = function(format, value) {};
 


### PR DESCRIPTION
The top-level Quill namespace wasn't properly declared and also there were multiple extraneous function externs with multiple arities.