### PR TITLE
Package tv4 for cljsjs

### DIFF
--- a/tv4/README.md
+++ b/tv4/README.md
@@ -1,0 +1,18 @@
+# cljsjs/tv4
+
+[](dependency)
+```clojure
+[cljsjs/tv4 "1.2.7"] ;; latest release
+```
+[](/dependency)
+
+This jar comes with `deps.cljs` as used by the [Foreign Libs][flibs] feature
+of the Clojurescript compiler. After adding the above dependency to your project
+you can require the packaged library like so:
+
+```clojure
+(ns application.core
+  (:require cljsjs.tv4))
+```
+
+[flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies

--- a/tv4/build.boot
+++ b/tv4/build.boot
@@ -1,0 +1,27 @@
+(set-env!
+  :resource-paths #{"resources"}
+  :dependencies '[[adzerk/bootlaces   "0.1.10" :scope "test"]
+                  [cljsjs/boot-cljsjs "0.5.0"  :scope "test"]])
+
+(require '[adzerk.bootlaces :refer :all]
+         '[cljsjs.boot-cljsjs.packaging :refer :all])
+
+(def +version+ "1.2.7-0")
+(bootlaces! +version+)
+
+(task-options!
+ pom  {:project     'cljsjs/tv4
+       :version     +version+
+       :description "Tiny Validator for v4 JSON Schema"
+       :url         "http://geraintluff.github.io/tv4/"
+       :scm         {:url "https://github.com/cljsjs/packages"}
+       :license     {"MIT" "http://opensource.org/licenses/mit-license.php"}})
+
+(deftask package []
+  (comp
+    (download :url "https://github.com/geraintluff/tv4/archive/v1.2.7.zip"
+              :unzip true)
+    (sift :move {#"^tv4-([\d\.]*)/tv4\.js"      "cljsjs/tv4/development/tv4.inc.js"
+                 #"^tv4-([\d\.]*)/tv4\.min\.js" "cljsjs/tv4/production/tv4.min.inc.js"})
+    (sift :include #{#"^cljsjs"})
+    (deps-cljs :name "cljsjs.tv4")))

--- a/tv4/resources/cljsjs/tv4/common/tv4.ext.js
+++ b/tv4/resources/cljsjs/tv4/common/tv4.ext.js
@@ -17,9 +17,18 @@ tv4.dropSchemas = function() {};
 tv4.defineKeyword = function() {};
 tv4.defineError = function() {};
 tv4.reset = function() {};
-tv4.missing = function() {};
-tv4.error = function() {};
-tv4.valid = function() {};
+tv4.missing = [];
+
+/**
+ * @type {?Object}
+ */
+tv4.error = null;
+
+/**
+ * @type {?boolean}
+ */
+tv4.valid = true;
+
 tv4.normSchema = function() {};
 tv4.resolveUrl = function() {};
 tv4.getDocumentUri = function() {};
@@ -27,7 +36,6 @@ tv4.getDocumentUri = function() {};
 /**
  * @enum {number}
  */
-
 tv4.errorCodes = {
     INVALID_TYPE: 0,
     ENUM_MISMATCH: 1,

--- a/tv4/resources/cljsjs/tv4/common/tv4.ext.js
+++ b/tv4/resources/cljsjs/tv4/common/tv4.ext.js
@@ -1,0 +1,61 @@
+var tv4 = {};
+
+tv4.setErrorReporter = function() {};
+tv4.addFormat = function() {};
+tv4.language = function() {};
+tv4.addLanguage = function() {};
+tv4.freshApi = function() {};
+tv4.validate = function() {};
+tv4.validateResult = function() {};
+tv4.validateMultiple = function() {};
+tv4.addSchema = function() {};
+tv4.getSchema = function() {};
+tv4.getSchemaMap = function() {};
+tv4.getSchemaUris = function() {};
+tv4.getMissingUris = function() {};
+tv4.dropSchemas = function() {};
+tv4.defineKeyword = function() {};
+tv4.defineError = function() {};
+tv4.reset = function() {};
+tv4.missing = function() {};
+tv4.error = function() {};
+tv4.valid = function() {};
+tv4.normSchema = function() {};
+tv4.resolveUrl = function() {};
+tv4.getDocumentUri = function() {};
+
+/**
+ * @enum {number}
+ */
+
+tv4.errorCodes = {
+    INVALID_TYPE: 0,
+    ENUM_MISMATCH: 1,
+    ANY_OF_MISSING: 10,
+    ONE_OF_MISSING: 11,
+    ONE_OF_MULTIPLE: 12,
+    NOT_PASSED: 13,
+    NUMBER_MULTIPLE_OF: 100,
+    NUMBER_MINIMUM: 101,
+    NUMBER_MINIMUM_EXCLUSIVE: 102,
+    NUMBER_MAXIMUM: 103,
+    NUMBER_MAXIMUM_EXCLUSIVE: 104,
+    NUMBER_NOT_A_NUMBER: 105,
+    STRING_LENGTH_SHORT: 200,
+    STRING_LENGTH_LONG: 201,
+    STRING_PATTERN: 202,
+    OBJECT_PROPERTIES_MINIMUM: 300,
+    OBJECT_PROPERTIES_MAXIMUM: 301,
+    OBJECT_REQUIRED: 302,
+    OBJECT_ADDITIONAL_PROPERTIES: 303,
+    OBJECT_DEPENDENCY_KEY: 304,
+    ARRAY_LENGTH_SHORT: 400,
+    ARRAY_LENGTH_LONG: 401,
+    ARRAY_UNIQUE: 402,
+    ARRAY_ADDITIONAL_ITEMS: 403,
+    FORMAT_CUSTOM: 500,
+    KEYWORD_CUSTOM: 501,
+    CIRCULAR_REFERENCE: 600,
+    UNKNOWN_PROPERTY: 1000 };
+
+tv4.tv4 = { };


### PR DESCRIPTION
[tv4](https://github.com/geraintluff/tv4) is a JavaScript library for validating [JSON Schema](http://json-schema.org) validation, based on v4 of the specification.

Closes https://github.com/okal/cljsjs-packages/issues/1