### PR TITLE
Fixed project url for react-input-mask

### DIFF
--- a/react-input-mask/build.boot
+++ b/react-input-mask/build.boot
@@ -12,7 +12,7 @@
  pom  {:project     'cljsjs/react-input-mask
        :version     +version+
        :description "Yet another react component for input masking"
-       :url         "http://https://github.com/sanniassin/react-input-mask"
+       :url         "https://github.com/sanniassin/react-input-mask"
        :scm         {:url "https://github.com/cljsjs/packages"}
        :license     {"MIT" "http://opensource.org/licenses/MIT"}})
 


### PR DESCRIPTION
It used to point to 'http://https://...', which is ill-formed.