### PR TITLE
[react-motion] Update to 0.4.1

### DIFF
--- a/react-motion/build.boot
+++ b/react-motion/build.boot
@@ -1,11 +1,15 @@
 (set-env!
   :resource-paths #{"resources"}
-  :dependencies '[[cljsjs/boot-cljsjs "0.5.0"  :scope "test"]
-                  [cljsjs/react       "0.13.3-1"]])
+  :dependencies '[[cljsjs/boot-cljsjs "0.5.1"  :scope "test"]
+                  [cljsjs/react       "0.14.3-0"]])
 
-(require '[cljsjs.boot-cljsjs.packaging :refer :all])
+(require '[cljsjs.boot-cljsjs.packaging :refer :all]
+         '[boot.core :as boot]
+         '[boot.tmpdir :as tmpd]
+         '[clojure.java.io :as io]
+         '[boot.util :refer [sh]])
 
-(def +lib-version+ "0.3.0")
+(def +lib-version+ "0.4.1")
 (def +version+ (str +lib-version+ "-0"))
 
 (task-options!
@@ -18,13 +22,32 @@
 
 (deftask download-react-motion []
   (download :url      (format "https://github.com/chenglou/react-motion/archive/v%s.zip" +lib-version+)
-            :checksum "C9C059E8BFEC88E7ABE321401011CA9B"
+            :checksum "6795EBF517CC68AB8B8144057995AE2F"
             :unzip    true))
+
+(deftask build-react-motion []
+  (let [tmp (boot/tmp-dir!)]
+           (with-pre-wrap
+             fileset
+             ;; Copy all files in fileset to temp directory
+             (doseq [f (->> fileset boot/input-files)
+                     :let [target (io/file tmp (tmpd/path f))]]
+               (io/make-parents target)
+               (io/copy (tmpd/file f) target))
+             (binding [boot.util/*sh-dir* (str (io/file tmp (format "react-motion-%s" +lib-version+)))]
+               ;; Missing -f flag for rm in npm build, fails if lib/ does not exist or isn't empty
+               ;; Already fixed in master, remove when updating to next release
+               ((sh "mkdir" "lib"))
+               ((sh "touch" "lib/foo"))
+               ((sh "npm" "install"))
+               ((sh "npm" "run" "prerelease")))
+             (-> fileset (boot/add-resource tmp) boot/commit!))))
 
 (deftask package []
   (comp
     (download-react-motion)
-    (sift :move {#"^react-.*/build/react-motion.js"
+    (build-react-motion)
+    (sift :move {#".*react-motion\.js$"
                  "cljsjs/react-motion/development/react-motion.inc.js"})
     (minify :in "cljsjs/react-motion/development/react-motion.inc.js"
             :out "cljsjs/react-motion/production/react-motion.min.inc.js")

--- a/react-motion/resources/cljsjs/react-motion/common/react-motion.ext.js
+++ b/react-motion/resources/cljsjs/react-motion/common/react-motion.ext.js
@@ -1,36 +1,32 @@
 // generated with http://www.dotnetwise.com/Code/Externs/
 // to regenerate from the tool:
-// first include http://fb.me/react-0.13.1.js
-// then https://rawgit.com/chenglou/react-motion/master/build/react-motion.js
+// first include http://fb.me/react-0.14.3.js
+// then https://npmcdn.com/react-motion/build/react-motion.js
 // and enter ReactMotion as the javascript object to extern
 
 var ReactMotion = {
     "__esModule": {},
-    "Spring": function () {},
-    "TransitionSpring": function () {},
     "Motion": function () {},
     "StaggeredMotion": function () {},
     "TransitionMotion": function () {},
     "spring": function () {},
     "presets": {
-        "noWobble": {
-            "0": {},
-            "1": {}
+        "noWobble": {7
+            "stiffness": {},
+            "damping": {}
         },
         "gentle": {
-            "0": {},
-            "1": {}
+            "stiffness": {},
+            "damping": {}
         },
         "wobbly": {
-            "0": {},
-            "1": {}
+            "stiffness": {},
+            "damping": {}
         },
         "stiff": {
-            "0": {},
-            "1": {}
+            "stiffness": {},
+            "damping": {}
         }
     },
-    "utils": {
-        "reorderKeys": function () {}
-    }
+    "reorderKeys": function () {}
 }


### PR DESCRIPTION
This PR still has a few issues:

* The react-motion release archive no longer includes the built js file, apparently it is now only served via `npmcdn.com`. I changed the package task to download from there but the task fails with:

    clojure.lang.ExceptionInfo: javax.net.ssl.SSLException: Received fatal alert: internal_error

Not sure if this an error on my end or with java and `npmcdn.com`. I did however put the js file on my own http server for testing and the download task worked as expected.

* The minify task fails on my rig with:

    clojure.lang.ExceptionInfo: java.lang.IllegalArgumentException: No implementation of method: :file of protocol: #'boot.tmpdir/ITmpFile found for class: nil

Looks like it can't find the input file, the sift task correctly moved the file though.

Removing the minify task allowed me to build and test the jar with a simple reagent project. Everything seems to be in order.

On a side note I had to include `clj-http` dependency, missing dependency of the `boot-cljsjs` task?
