### PR TITLE
[chartist] Fix chartist Line extern

### DIFF
--- a/chartist/build.boot
+++ b/chartist/build.boot
@@ -4,7 +4,7 @@
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
-(def +lib-version+ "0.9.4")
+(def +lib-version+ "0.9.5")
 (def +version+ (str +lib-version+ "-1"))
 
 (task-options!

--- a/chartist/build.boot
+++ b/chartist/build.boot
@@ -4,8 +4,8 @@
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
-(def +lib-version+ "0.9.5")
-(def +version+ (str +lib-version+ "-1"))
+(def +lib-version+ "0.9.4")
+(def +version+ (str +lib-version+ "-2"))
 
 (task-options!
   pom {:project 'cljsjs/chartist

--- a/chartist/resources/cljsjs/common/chartist.ext.js
+++ b/chartist/resources/cljsjs/common/chartist.ext.js
@@ -48,7 +48,7 @@ var Chartist = {
   AutoScaleAxis: function(){},
   FixedScaleAxis: function(){},
   StepAxis: function(){},
-  Linex: function(){},
+  Line: function(){},
   Bar: function(){},
   Pie: function(){}
 }


### PR DESCRIPTION
The API is `Line`; the extern has `Linex`. Likely a typo.