### PR TITLE
[codemirror] Add mode/meta.js

### DIFF
--- a/codemirror/build.boot
+++ b/codemirror/build.boot
@@ -7,7 +7,7 @@
 (def +lib-version+ "5.11.0")
 (def codemirror-checksum "a8d5b27ae5ab0d898930aef314afba1c")
 
-(def +version+ (str +lib-version+ "-0"))
+(def +version+ (str +lib-version+ "-1"))
 
 (task-options!
   pom  {:project     'cljsjs/codemirror
@@ -52,6 +52,7 @@
               :checksum codemirror-checksum)
     (sift :move {#"^CodeMirror-([\d\.]*)/lib/codemirror\.js"    "cljsjs/codemirror/development/codemirror.inc.js"
                  #"^CodeMirror-([\d\.]*)/lib/codemirror\.css"   "cljsjs/codemirror/development/codemirror.css"
+                 #"^CodeMirror-([\d\.]*)/mode/meta\.js"         "cljsjs/codemirror/common/mode/meta.js"
                  #"^CodeMirror-([\d\.]*)/mode/(.*)/\2\.js"      "cljsjs/codemirror/common/mode/$2.js"
                  #"^CodeMirror-([\d\.]*)/keymap/(.*)\.js"       "cljsjs/codemirror/common/keymap/$2.js"
                  #"^CodeMirror-([\d\.]*)/addon/(.*)/(.*)\.css"  "cljsjs/codemirror/common/addon/$2/$3.css"


### PR DESCRIPTION
meta.js lives in the root of the mode directory rather than a
subdirectory, so it is not picked up by the regular mode regex. It is
not itself a mode - it contains function to map extensions, mime types,
and names to modes.  However, since it is closely related to modes and
it seems unlikely there will ever be a "meta" mode I think it makes
sense to place it under cljsjs.codemirror.mode in the namespace
hierarchy. I'm open to suggestions on the placement though if anyone
has other suggestions.