### PR TITLE
[react-grid-layout] bump to version 0.10.8

### DIFF
--- a/react-grid-layout/README.md
+++ b/react-grid-layout/README.md
@@ -2,7 +2,7 @@
 
 [](dependency)
 ```clojure
-[cljsjs/react-grid-layout "0.8.5-0"] ;; latest release
+[cljsjs/react-grid-layout "0.10.8-0"] ;; latest release
 ```
 [](/dependency)
 

--- a/react-grid-layout/build.boot
+++ b/react-grid-layout/build.boot
@@ -1,12 +1,12 @@
+(def +lib-version+ "0.10.8")
+(def +version+ (str +lib-version+ "-0"))
+
 (set-env!
   :resource-paths #{"resources"}
   :dependencies '[[cljsjs/boot-cljsjs "0.5.0"  :scope "test"]
                   [cljsjs/react "0.14.3-0"]])
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
-
-(def +lib-version+ "0.8.5")
-(def +version+ (str +lib-version+ "-0"))
 
 (task-options!
  pom  {:project     'cljsjs/react-grid-layout
@@ -16,18 +16,13 @@
        :scm         {:url "https://github.com/cljsjs/packages"}
        :license     {"MIT" "http://opensource.org/licenses/MIT"}})
 
-(require '[boot.core :as c]
-         '[boot.tmpdir :as tmpd]
-         '[clojure.java.io :as io]
-         '[clojure.string :as string])
-
 (deftask package []
   (comp
     (download :url (str "https://github.com/STRML/react-grid-layout/archive/" +lib-version+ ".zip")
-	      :checksum "A052FED2986574E07BE4B1B643E0C80A"
-	      :unzip true)
+              :checksum "F7AFBA1CF5ED4207C021AAD63C04A428"
+              :unzip true)
 
-    (sift :move {#"^react-grid-layout.*[/ \\]dist[/ \\]react-grid-layout.min.js$" "cljsjs/react-input-autosize/development/react-grid-layout.inc.js"})
+    (sift :move {#"^react-grid-layout.*[/ \\]dist[/ \\]react-grid-layout.min.js$" "cljsjs/react-grid-layout/development/react-grid-layout.inc.js"})
 
     (sift :include #{#"^cljsjs"})
     (deps-cljs :name "cljsjs.react-grid-layout"

--- a/react-grid-layout/resources/cljsjs/react-grid-layout/common/react-grid-layout.ext.js
+++ b/react-grid-layout/resources/cljsjs/react-grid-layout/common/react-grid-layout.ext.js
@@ -1,37 +1,35 @@
 var ReactGridLayout = {
     "propTypes": {
-        "initialWidth": function () {},
-        "listenToWindowResize": function () {},
+        "width": function () {},
         "autoSize": function () {},
         "cols": function () {},
-        "draggableCancel": function () {},
-        "draggableHandle": function () {},
-        "verticalCompact": function () {},
-        "layout": function () {},
-        "layouts": function () {},
-        "margin": function () {},
-        "rowHeight": function () {},
-        "isDraggable": function () {},
-        "isResizable": function () {},
-        "useCSSTransforms": function () {},
-        "onLayoutChange": function () {},
-        "onDragStart": function () {},
-        "onDrag": function () {},
-        "onDragStop": function () {},
-        "onResizeStart": function () {},
-        "onResize": function () {},
-        "onResizeStop": function () {},
-        "children": function () {}
+        "draggableCancel": function() {},
+        "draggableHandle": function() {},
+        "verticalCompact": function() {},
+        "layout": function() {},
+        "margin": function() {},
+        "rowHeight": function() {},
+        "maxRows": function() {},
+        "isDraggable": function() {},
+        "isResizable": function() {},
+        "useCSSTransforms": function() {},
+        "onLayoutChange": function() {},
+        "onDragStart": function() {},
+        "onDrag": function() {},
+        "onDragStop": function() {},
+        "onResizeStart": function() {},
+        "onResize": function() {},
+        "onResizeStop": function() {},
+        "children": function() {}
     },
     "getDefaultProps": function () {},
     "displayName": {},
     "defaultProps": {
-        "initialWidth": {},
-        "listenToWindowResize": {},
         "autoSize": {},
         "cols": {},
         "rowHeight": {},
-        "layout": function () {},
+        "maxRows": {},
+        "layout": function() {},
         "margin": {
             "0": {},
             "1": {}
@@ -40,14 +38,68 @@ var ReactGridLayout = {
         "isResizable": {},
         "useCSSTransforms": {},
         "verticalCompact": {},
-        "onLayoutChange": function () {},
-        "onDragStart": function () {},
-        "onDrag": function () {},
-        "onDragStop": function () {},
-        "onResizeStart": function () {},
-        "onResize": function () {},
-        "onResizeStop": function () {}
+        "onLayoutChange": function() {},
+        "onDragStart": function() {},
+        "onDrag": function() {},
+        "onDragStop": function() {},
+        "onResizeStart": function() {},
+        "onResize": function() {},
+        "onResizeStop": function() {}
     },
-    "Responsive": function () {}
-}
+    "Responsive": {
+        "propTypes": {
+            "breakpoint": {},
+            "breakpoints": {},
+            "cols": {},
+            "layouts": function() {},
+            "width": {},
+            "onBreakpointChange": function() {},
+            "onLayoutChange": function() {},
+            "onWidthChange": function() {}
+        },
+        "defaultProps": {
+            "breakpoints": {},
+            "cols": {},
+            "layouts": {},
+            "onBreakpointChange": function() {},
+            "onLayoutChange": function() {},
+            "onWidthChange": function() {}
+        }
+    },
+    "WidthProvider": function () {}
+};
 
+var React = {};
+
+React.ReactAttribute = function() {};
+
+React.ReactAttribute._grid = {
+    "children": {},
+    "cols": {},
+    "containerWidth": {},
+    "rowHeight": {},
+    "margin": {},
+    "maxRows": {},
+    "x": {},
+    "y": {},
+    "w": {},
+    "h": {},
+    "minW": function() {},
+    "maxW": function() {},
+    "minH": function() {},
+    "maxH": function() {},
+    "i": {},
+    "onDragStop": function() {},
+    "onDragStart": function() {},
+    "onDrag": function() {},
+    "onResizeStop": function() {},
+    "onResizeStart": function() {},
+    "onResize": function() {},
+    "isDraggable": {},
+    "isResizable": {},
+    "useCSSTransforms": {},
+    "isPlaceholder": {},
+    "className": {},
+    "handle": {},
+    "cancel": {}
+};


### PR DESCRIPTION
There was one part I was not completely sure about. Grid elements can have a magic prop, called `_grid`, that gets used by ReactGridLayout. So we don't want it to get compiled away in our source.
https://github.com/STRML/react-grid-layout#usage

So I put it on `React.ReactAttribute`, just like the `key` prop.
https://github.com/cljsjs/packages/blob/master/react/resources/cljsjs/react/common/react.ext.js#L282

I'm not sure if this is the correct way to do it.