### PR TITLE
fix react-input-mask

### DIFF
--- a/react-input-mask/build.boot
+++ b/react-input-mask/build.boot
@@ -6,7 +6,7 @@
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
 (def +lib-version+ "0.5.10")
-(def +version+ (str +lib-version+ "-0"))
+(def +version+ (str +lib-version+ "-1"))
 
 (task-options!
  pom  {:project     'cljsjs/react-input-mask
@@ -23,8 +23,8 @@
 
 (deftask package []
   (comp
-    (download :url "https://raw.githubusercontent.com/sanniassin/react-input-mask/05c101e4937d54966f673113a1432afb53fb9541/InputElement.js"
-              :checksum "9119D65B8CCEA2EFF7B5BAE748528B1F")
+    (download :url "https://raw.githubusercontent.com/sanniassin/react-input-mask/05c101e4937d54966f673113a1432afb53fb9541/build/InputElement.js"
+              :checksum "43D89151C1CF4F37100CFA50DCA54B42")
 
     (sift :move {#"^InputElement.js$" "cljsjs/react-input-mask/development/react-input-mask.inc.js"})
 


### PR DESCRIPTION
react-input-mask now uses ES6 in sources and provides separate build file 