### PR TITLE
Fix google-diff-match-patch production build

### DIFF
--- a/google-diff-match-patch/README.md
+++ b/google-diff-match-patch/README.md
@@ -2,7 +2,7 @@
 
 [](dependency)
 ```clojure
-[cljsjs/google-diff-match-patch "20121119-0"] ;; latest release
+[cljsjs/google-diff-match-patch "20121119-1"] ;; latest release
 ```
 [](/dependency)
 

--- a/google-diff-match-patch/build.boot
+++ b/google-diff-match-patch/build.boot
@@ -21,8 +21,7 @@
    (download :url (format "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/google-diff-match-patch/diff_match_patch_%s.zip" +lib-version+)
              :checksum "c0d22f0c04da5760ecb2c2040daa6703"
              :unzip true)
-   (sift :move {#"^diff_match_patch_\d*/javascript/diff_match_patch_uncompressed\.js$" "cljsjs/google-diff-match-patch/development/google-diff-match-patch.inc.js"
-                #"^diff_match_patch_\d*/javascript/diff_match_patch_uncompressed\.js$" "cljsjs/google-diff-match-patch/production/google-diff-match-patch.min.inc.js"})
+   (sift :move {#"^diff_match_patch_\d*/javascript/diff_match_patch_uncompressed\.js$" "cljsjs/google-diff-match-patch/development/google-diff-match-patch.inc.js"})
    (sift :include #{#"^cljsjs"})
    (deps-cljs :name "cljsjs.google-diff-match-patch")
    (pom)

--- a/google-diff-match-patch/build.boot
+++ b/google-diff-match-patch/build.boot
@@ -6,7 +6,7 @@
 
 
 (def +lib-version+ "20121119")
-(def +version+ (str +lib-version+ "-0"))
+(def +version+ (str +lib-version+ "-1"))
 
 (task-options!
  pom  {:project     'cljsjs/google-diff-match-patch
@@ -22,7 +22,7 @@
              :checksum "c0d22f0c04da5760ecb2c2040daa6703"
              :unzip true)
    (sift :move {#"^diff_match_patch_\d*/javascript/diff_match_patch_uncompressed\.js$" "cljsjs/google-diff-match-patch/development/google-diff-match-patch.inc.js"
-                #"^diff_match_patch_\d*/javascript/diff_match_patch\.js$"              "cljsjs/google-diff-match-patch/production/google-diff-match-patch.min.inc.js"})
+                #"^diff_match_patch_\d*/javascript/diff_match_patch_uncompressed\.js$" "cljsjs/google-diff-match-patch/production/google-diff-match-patch.min.inc.js"})
    (sift :include #{#"^cljsjs"})
    (deps-cljs :name "cljsjs.google-diff-match-patch")
    (pom)


### PR DESCRIPTION
The distributed minified version of the library is missing a semi-colon that causes a cryptic error message when you use more than one cljsjs package in a project, didn't notice until now.