### PR TITLE
add google platform library (for authentication)

### DIFF
--- a/platform/README.md
+++ b/platform/README.md
@@ -1,0 +1,27 @@
+# cljsjs/platform
+
+[](dependency)
+```clojure
+[cljsjs/platform "1.0.0-0"] ;; latest release
+```
+[](/dependency)
+
+Note: Google does not version its api library since they prefer people to use is through their cdn. Therefore, the checksum may be incorrect. If you run into this problem, follow these steps:
+
+1. wget https://apis.google.com/js/platform.js
+2. run boot package
+3. copy the correct checksum from the log
+4. replace the checksum in build.boot with the current one
+
+This jar comes with `deps.cljs` as used by the [Foreign Libs][flibs] feature
+of the Clojurescript compiler. After adding the above dependency to your project
+you can require the packaged library like so:
+
+```clojure
+(ns application.core
+  (:require cljsjs.aws-sdk-js))
+```
+
+Documentation for the platform lib can be found [on this page](https://developers.google.com/+/web/api/javascript)
+
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies

--- a/platform/build.boot
+++ b/platform/build.boot
@@ -1,0 +1,40 @@
+(set-env!
+  :resource-paths #{"resources"}
+  :dependencies '[[cljsjs/boot-cljsjs "0.5.0" :scope "test"]])
+
+(require '[boot.task-helpers]
+         '[cljsjs.boot-cljsjs.packaging :refer :all])
+
+
+(def +lib-version+ "1.0.0")
+(def +version+ (str +lib-version+ "-0"))
+
+(task-options!
+  push {:ensure-clean false}
+  pom  {:project     'cljsjs/platform
+        :version     +version+
+        :description "Authenticate with Google API"
+        :url         "https://apis.google.com/js/platform.js"
+        :license     {"MIT" "https://opensource.org/licenses/MIT"}
+        :scm         {:url "https://github.com/cljsjs/packages"}})
+
+(require '[boot.core :as c]
+         '[boot.tmpdir :as tmpd]
+         '[clojure.java.io :as io]
+         '[clojure.string :as string])
+
+(deftask package []
+  (comp
+   (download :url (format "https://apis.google.com/js/platform.js")
+             :checksum "e6771ebfb2ba29448405372e3de8da27"
+             :unzip false)
+
+
+   (sift :move {#"platform.js"  "cljsjs/platform/development/platform.inc.js"
+                #"platform.js"  "cljsjs/platform/production/platform.inc.js"})
+
+   (sift :include #{#"^cljsjs"})
+
+   (deps-cljs :name "cljsjs.platform")
+   (pom)
+   (jar)))

--- a/platform/resources/cljsjs/platform/common/platform.ext.js
+++ b/platform/resources/cljsjs/platform/common/platform.ext.js
@@ -1,0 +1,20 @@
+var gapi = {
+    "auth2": {
+        "GoogleUser": {"isSignedIn": function(){},
+                       "getBasicProfile": function(){return {"getId": function(){},
+                                                             "getName": function(){},
+                                                             "getImageUrl": function(){},
+                                                             "getEmail": function(){}
+                                                            }}},
+        "init": function(){
+            return {"currentUser": {"listen": function(){},
+                                    "get": function(){
+                                        return {"getAuthResponse": function(){
+                                            return {"id_token": ""}}}}}}},
+        "getAuthInstance": function(){
+            return {"signOut": function(){},
+                    "signIn": function(){}}
+        },
+    },
+    "load": function () {}
+}


### PR DESCRIPTION
This is the library that you need to use google's oauth2 authentication. There are some quirks. It seems that Google wants to force you to use their CDN and does not have a public repo or github repo for this library. Therefore the version that I mention is bogus (google does not externally version this) and it may break unexpectedly. When this occurs, an easy fix is described in the README