### PR TITLE
update vega and add vega-lite

### DIFF
--- a/vega-lite/README.md
+++ b/vega-lite/README.md
@@ -1,0 +1,18 @@
+# cljsjs/vega-lite
+
+[](dependency)
+```clojure
+[cljsjs/vega-lite "1.0.8-0"] ;; latest release
+```
+[](/dependency)
+
+This jar comes with `deps.cljs` as used by the [Foreign Libs][flibs] feature
+of the Clojurescript compiler. After adding the above dependency to your project
+you can require the packaged library like:
+
+```clojure
+(ns application.core
+  (:require cljsjs.vega-lite))
+```
+
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies

--- a/vega-lite/build.boot
+++ b/vega-lite/build.boot
@@ -1,0 +1,32 @@
+(set-env!
+  :resource-paths #{"resources"}
+  :dependencies '[[cljsjs/boot-cljsjs "0.5.0" :scope "test"]
+                  [cljsjs/vega "2.5.0-0"]])
+
+(require '[cljsjs.boot-cljsjs.packaging :refer :all])
+
+(def +lib-version+ "1.0.8")
+
+(def +version+ (str +lib-version+ "-0"))
+
+(task-options!
+  pom {:project     'cljsjs/vega-lite
+       :version     +version+
+       :description "A high-level grammar for visual analysis, built on top of Vega."
+       :url         "https://vega.github.io/vega-lite"
+       :scm         {:url "https://github.com/cljsjs/packages"}})
+
+(deftask package []
+  (task-options! push {:ensure-branch nil})
+  (comp
+    (download
+      :url (str "https://github.com/vega/vega-lite/archive/v" +lib-version+ ".zip")
+      :unzip true
+      :checksum "468EE30FEA222391B1AAB8E2F9A1158B")
+    (sift :move {(re-pattern (str "^vega-lite-" +lib-version+ "/vega-lite.js$")) "cljsjs/development/vega-lite.inc.js"
+                 (re-pattern (str "^vega-lite-" +lib-version+ "/vega-lite.min.js$")) "cljsjs/production/vega-lite.min.inc.js"})
+    (sift :include #{#"^cljsjs"})
+    (deps-cljs :name "cljsjs.vega-lite"
+               :requires ["cljsjs.vega"])
+    (pom)
+    (jar)))

--- a/vega-lite/resources/cljsjs/common/vega-lite.ext.js
+++ b/vega-lite/resources/cljsjs/common/vega-lite.ext.js
@@ -1,0 +1,7 @@
+var vl = {};
+
+/**
+ * @param {(string|Object)} spec
+ */
+
+vl.compile = function (spec) {};

--- a/vega/README.md
+++ b/vega/README.md
@@ -2,7 +2,7 @@
 
 [](dependency)
 ```clojure
-[cljsjs/vega "2.3.1-0"] ;; latest release
+[cljsjs/vega "2.5.0-0"] ;; latest release
 ```
 [](/dependency)
 

--- a/vega/build.boot
+++ b/vega/build.boot
@@ -5,7 +5,7 @@
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
-(def +lib-version+ "2.3.1")
+(def +lib-version+ "2.5.0")
 
 (def +version+ (str +lib-version+ "-0"))
 
@@ -22,7 +22,7 @@
     (download
       :url (str "https://github.com/vega/vega/archive/v" +lib-version+ ".zip")
       :unzip true
-      :checksum "3F4EEA134574B20326A165C7B3AB3FB6")
+      :checksum "5AFB54BE6EBACB09A8EC84432F28E791")
     (sift :move {(re-pattern (str "^vega-" +lib-version+ "/vega.js$")) "cljsjs/development/vega.inc.js"
                  (re-pattern (str "^vega-" +lib-version+ "/vega.min.js$")) "cljsjs/production/vega.min.inc.js"})
     (sift :include #{#"^cljsjs"})


### PR DESCRIPTION
* updates vega to 2.5.0
* add vega-lite as a separate package, which depends on vega