### PR TITLE
[chartist] extend externs

### DIFF
--- a/chartist/build.boot
+++ b/chartist/build.boot
@@ -5,7 +5,7 @@
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
 (def +lib-version+ "0.9.4")
-(def +version+ (str +lib-version+ "-2"))
+(def +version+ (str +lib-version+ "-3"))
 
 (task-options!
   pom {:project 'cljsjs/chartist

--- a/chartist/resources/cljsjs/common/chartist.ext.js
+++ b/chartist/resources/cljsjs/common/chartist.ext.js
@@ -38,7 +38,12 @@ var Chartist = {
   "createLabel": function () {},
   "getSeriesOption": function () {},
   "optionsProvider": function () {},
-  "Interpolation": {},
+  "Interpolation": {
+    "none": function () {},
+    "simple": function () {},
+    "cardinal": function () {},
+    "step": function () {},
+  }
   "EventEmitter": function () {},
   "Class": {},
   "Base": {

--- a/chartist/resources/cljsjs/common/chartist.ext.js
+++ b/chartist/resources/cljsjs/common/chartist.ext.js
@@ -1,54 +1,234 @@
 var Chartist = {
-  version: {},
-  noop: function(){},
-  alphaNumerate: function(){},
-  extend: function(){},
-  replaceAll: function(){},
-  stripUnit: function(){},
-  ensureUnit: function(){},
-  querySelector: function(){},
-  times: function(){},
-  sum: function(){},
-  mapMultiply: function(){},
-  mapAdd: function(){},
-  serialMap: function(){},
-  roundWithPrecision: function(){},
-  precision: {},
-  escapingMap: {},
-  serialize: function(){},
-  deserialize: function(){},
-  createSvg: function(){},
-  reverseData: function(){},
-  getDataArray: function(){},
-  normalizePadding: function(){},
-  getMetaData: function(){},
-  orderOfMagnitude: function(){},
-  projectLength: function(){},
-  getAvailableHeight: function(){},
-  getHighLow: function(){},
-  isNum: function(){},
-  isFalseyButZero: function(){},
-  getNumberOrUndefined: function(){},
-  getMultiValue: function(){},
-  rho: function(){},
-  getBounds: function(){},
-  polarToCartesian: function(){},
-  createChartRect: function(){},
-  createGrid: function(){},
-  createLabel: function(){},
-  getSeriesOption: function(){},
-  optionsProvider: function(){},
-  Interpolation: {},
-  EventEmitter: function(){},
-  Class: {},
-  Base: function(){},
-  xmlNs: {},
-  Svg: function(){},
-  Axis: function(){},
-  AutoScaleAxis: function(){},
-  FixedScaleAxis: function(){},
-  StepAxis: function(){},
-  Line: function(){},
-  Bar: function(){},
-  Pie: function(){}
-}
+  "version": {},
+  "noop": function () {},
+  "alphaNumerate": function () {},
+  "extend": function () {},
+  "replaceAll": function () {},
+  "stripUnit": function () {},
+  "ensureUnit": function () {},
+  "querySelector": function () {},
+  "times": function () {},
+  "sum": function () {},
+  "mapMultiply": function () {},
+  "mapAdd": function () {},
+  "serialMap": function () {},
+  "roundWithPrecision": function () {},
+  "precision": {},
+  "escapingMap": {},
+  "serialize": function () {},
+  "deserialize": function () {},
+  "createSvg": function () {},
+  "reverseData": function () {},
+  "getDataArray": function () {},
+  "normalizePadding": function () {},
+  "getMetaData": function () {},
+  "orderOfMagnitude": function () {},
+  "projectLength": function () {},
+  "getAvailableHeight": function () {},
+  "getHighLow": function () {},
+  "isNum": function () {},
+  "isFalseyButZero": function () {},
+  "getNumberOrUndefined": function () {},
+  "getMultiValue": function () {},
+  "rho": function () {},
+  "getBounds": function () {},
+  "polarToCartesian": function () {},
+  "createChartRect": function () {},
+  "createGrid": function () {},
+  "createLabel": function () {},
+  "getSeriesOption": function () {},
+  "optionsProvider": function () {},
+  "Interpolation": {},
+  "EventEmitter": function () {},
+  "Class": {},
+  "Base": {
+    "super": {},
+    "extend": function () {}
+  },
+  "xmlNs": {},
+  "Svg": {
+    "super": {},
+    "extend": function () {},
+    "isSupported": function () {},
+    "Easing": {},
+    "List": {
+      "super": {},
+      "extend": function () {}
+    },
+    "Path": {
+      "super": {},
+      "extend": function () {},
+      "elementDescriptions": {},
+      "join": function () {}
+    }
+  },
+  "Axis": {
+    "super": {},
+    "extend": function () {},
+    "units": {}
+  },
+  "AutoScaleAxis": {
+    "super": {},
+    "extend": function () {}
+  },
+  "FixedScaleAxis": {
+    "super": {},
+    "extend": function () {}
+  },
+  "StepAxis": {
+    "super": {},
+    "extend": function () {}
+  },
+  "Line": {
+    "super": {},
+    "extend": function () {}
+  },
+  "Bar": {
+    "super": {},
+    "extend": function () {}
+  },
+  "Pie": {
+    "super": {},
+    "extend": function () {}
+  }
+};
+Chartist.Base.prototype = {
+  "constructor": function () {},
+  "optionsProvider": function () {},
+  "container": function () {},
+  "svg": function () {},
+  "eventEmitter": function () {},
+  "createChart": function () {},
+  "update": function () {},
+  "detach": function () {},
+  "on": function () {},
+  "off": function () {},
+  "version": function () {},
+  "supportsForeignObject": function () {},
+  "extend": function () {},
+  "cloneDefinitions": function () {}
+};
+Chartist.Svg.prototype = {
+  "constructor": function () {},
+  "attr": function () {},
+  "elem": function () {},
+  "parent": function () {},
+  "root": function () {},
+  "querySelector": function () {},
+  "querySelectorAll": function () {},
+  "foreignObject": function () {},
+  "text": function () {},
+  "empty": function () {},
+  "remove": function () {},
+  "replace": function () {},
+  "append": function () {},
+  "classes": function () {},
+  "addClass": function () {},
+  "removeClass": function () {},
+  "removeAllClasses": function () {},
+  "height": function () {},
+  "width": function () {},
+  "animate": function () {},
+  "extend": function () {},
+  "cloneDefinitions": function () {}
+};
+Chartist.Svg.List.prototype = {
+  "constructor": function () {},
+  "extend": function () {},
+  "cloneDefinitions": function () {}
+};
+Chartist.Svg.Path.prototype = {
+  "constructor": function () {},
+  "position": function () {},
+  "remove": function () {},
+  "move": function () {},
+  "line": function () {},
+  "curve": function () {},
+  "arc": function () {},
+  "scale": function () {},
+  "translate": function () {},
+  "transform": function () {},
+  "parse": function () {},
+  "stringify": function () {},
+  "clone": function () {},
+  "splitByCommand": function () {},
+  "extend": function () {},
+  "cloneDefinitions": function () {}
+};
+Chartist.Axis.prototype = {
+  "constructor": function () {},
+  "createGridAndLabels": function () {},
+  "projectValue": function () {},
+  "extend": function () {},
+  "cloneDefinitions": function () {}
+};
+Chartist.AutoScaleAxis.prototype = {
+  "constructor": function () {},
+  "projectValue": function () {},
+  "createGridAndLabels": function () {},
+  "extend": function () {},
+  "cloneDefinitions": function () {}
+};
+Chartist.FixedScaleAxis.prototype = {
+  "constructor": function () {},
+  "projectValue": function () {},
+  "createGridAndLabels": function () {},
+  "extend": function () {},
+  "cloneDefinitions": function () {}
+};
+Chartist.StepAxis.prototype = {
+  "constructor": function () {},
+  "projectValue": function () {},
+  "createGridAndLabels": function () {},
+  "extend": function () {},
+  "cloneDefinitions": function () {}
+};
+Chartist.Line.prototype = {
+  "constructor": function () {},
+  "createChart": function () {},
+  "optionsProvider": function () {},
+  "container": function () {},
+  "svg": function () {},
+  "eventEmitter": function () {},
+  "update": function () {},
+  "detach": function () {},
+  "on": function () {},
+  "off": function () {},
+  "version": function () {},
+  "supportsForeignObject": function () {},
+  "extend": function () {},
+  "cloneDefinitions": function () {}
+};
+Chartist.Bar.prototype = {
+  "constructor": function () {},
+  "createChart": function () {},
+  "optionsProvider": function () {},
+  "container": function () {},
+  "svg": function () {},
+  "eventEmitter": function () {},
+  "update": function () {},
+  "detach": function () {},
+  "on": function () {},
+  "off": function () {},
+  "version": function () {},
+  "supportsForeignObject": function () {},
+  "extend": function () {},
+  "cloneDefinitions": function () {}
+};
+Chartist.Pie.prototype = {
+  "constructor": function () {},
+  "createChart": function () {},
+  "determineAnchorPosition": function () {},
+  "optionsProvider": function () {},
+  "container": function () {},
+  "svg": function () {},
+  "eventEmitter": function () {},
+  "update": function () {},
+  "detach": function () {},
+  "on": function () {},
+  "off": function () {},
+  "version": function () {},
+  "supportsForeignObject": function () {},
+  "extend": function () {},
+  "cloneDefinitions": function () {}
+};


### PR DESCRIPTION
this extends the chartist externs in two ways:

1. try to get to something "as complete as possible" using [a generator](http://jmmk.github.io/javascript-externs-generator/)
2. add interpolation functions that are missing from externs otherwise