### PR TITLE
[react-grid-layout] Update to version 0.12.3

### DIFF
--- a/react-grid-layout/README.md
+++ b/react-grid-layout/README.md
@@ -2,7 +2,7 @@
 
 [](dependency)
 ```clojure
-[cljsjs/react-grid-layout "0.10.8-0"] ;; latest release
+[cljsjs/react-grid-layout "0.12.3-0"] ;; latest release
 ```
 [](/dependency)
 

--- a/react-grid-layout/build.boot
+++ b/react-grid-layout/build.boot
@@ -1,10 +1,10 @@
-(def +lib-version+ "0.10.8")
+(def +lib-version+ "0.12.3")
 (def +version+ (str +lib-version+ "-0"))
 
 (set-env!
   :resource-paths #{"resources"}
   :dependencies '[[cljsjs/boot-cljsjs "0.5.1"  :scope "test"]
-                  [cljsjs/react "0.14.3-0"]])
+                  [cljsjs/react "15.0.2-0"]])
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
@@ -19,10 +19,11 @@
 (deftask package []
   (comp
     (download :url (str "https://github.com/STRML/react-grid-layout/archive/" +lib-version+ ".zip")
-              :checksum "F7AFBA1CF5ED4207C021AAD63C04A428"
+              :checksum "832a36551e97eb466652cbfddd99500d"
               :unzip true)
 
-    (sift :move {#"^react-grid-layout.*[/ \\]dist[/ \\]react-grid-layout.min.js$" "cljsjs/react-grid-layout/development/react-grid-layout.inc.js"})
+    (sift :move {#"^react-grid-layout-(.*)/dist/react-grid-layout.min.js$" "cljsjs/react-grid-layout/development/react-grid-layout.inc.js"
+                 #"^react-grid-layout-(.*)/css/styles.css$" "cljsjs/react-grid-layout/common/react-virtualized.inc.css"})
 
     (sift :include #{#"^cljsjs"})
     (deps-cljs :name "cljsjs.react-grid-layout"

--- a/react-grid-layout/resources/cljsjs/react-grid-layout/common/react-grid-layout.ext.js
+++ b/react-grid-layout/resources/cljsjs/react-grid-layout/common/react-grid-layout.ext.js
@@ -1,105 +1,48 @@
+// Generated via http://jmmk.github.io/javascript-externs-generator/
+// Import react via cdn
+// Import react-grid-layout via rawgit
+
+// Loaded JavaScripts:
+// https://cdnjs.cloudflare.com/ajax/libs/react/15.0.2/react.js
+// https://rawgit.com/STRML/react-grid-layout/0.12.3/dist/react-grid-layout.min.js
+
+// Reference ns as ReactGridLayout
+
 var ReactGridLayout = {
-    "propTypes": {
-        "width": function () {},
-        "autoSize": function () {},
-        "cols": function () {},
-        "draggableCancel": function() {},
-        "draggableHandle": function() {},
-        "verticalCompact": function() {},
-        "layout": function() {},
-        "margin": function() {},
-        "rowHeight": function() {},
-        "maxRows": function() {},
-        "isDraggable": function() {},
-        "isResizable": function() {},
-        "useCSSTransforms": function() {},
-        "onLayoutChange": function() {},
-        "onDragStart": function() {},
-        "onDrag": function() {},
-        "onDragStop": function() {},
-        "onResizeStart": function() {},
-        "onResize": function() {},
-        "onResizeStop": function() {},
-        "children": function() {}
-    },
-    "getDefaultProps": function () {},
-    "displayName": {},
-    "defaultProps": {
-        "autoSize": {},
-        "cols": {},
-        "rowHeight": {},
-        "maxRows": {},
-        "layout": function() {},
-        "margin": {
-            "0": {},
-            "1": {}
-        },
-        "isDraggable": {},
-        "isResizable": {},
-        "useCSSTransforms": {},
-        "verticalCompact": {},
-        "onLayoutChange": function() {},
-        "onDragStart": function() {},
-        "onDrag": function() {},
-        "onDragStop": function() {},
-        "onResizeStart": function() {},
-        "onResize": function() {},
-        "onResizeStop": function() {}
-    },
-    "Responsive": {
-        "propTypes": {
-            "breakpoint": {},
-            "breakpoints": {},
-            "cols": {},
-            "layouts": function() {},
-            "width": {},
-            "onBreakpointChange": function() {},
-            "onLayoutChange": function() {},
-            "onWidthChange": function() {}
-        },
-        "defaultProps": {
-            "breakpoints": {},
-            "cols": {},
-            "layouts": {},
-            "onBreakpointChange": function() {},
-            "onLayoutChange": function() {},
-            "onWidthChange": function() {}
-        }
-    },
-    "WidthProvider": function () {}
+  "displayName": {},
+  "propTypes": {},
+  "defaultProps": {},
+  "utils": {},
+  "Responsive": {
+    "propTypes": {},
+    "defaultProps": {},
+    "utils": {}
+  },
+  "WidthProvider": function () {}
 };
-
-var React = {};
-
-React.ReactAttribute = function() {};
-
-React.ReactAttribute._grid = {
-    "children": {},
-    "cols": {},
-    "containerWidth": {},
-    "rowHeight": {},
-    "margin": {},
-    "maxRows": {},
-    "x": {},
-    "y": {},
-    "w": {},
-    "h": {},
-    "minW": function() {},
-    "maxW": function() {},
-    "minH": function() {},
-    "maxH": function() {},
-    "i": {},
-    "onDragStop": function() {},
-    "onDragStart": function() {},
-    "onDrag": function() {},
-    "onResizeStop": function() {},
-    "onResizeStart": function() {},
-    "onResize": function() {},
-    "isDraggable": {},
-    "isResizable": {},
-    "useCSSTransforms": {},
-    "isPlaceholder": {},
-    "className": {},
-    "handle": {},
-    "cancel": {}
+ReactGridLayout.prototype = {
+  "componentDidMount": function () {},
+  "componentWillReceiveProps": function () {},
+  "containerHeight": function () {},
+  "onDragStart": function () {},
+  "onDrag": function () {},
+  "onDragStop": function () {},
+  "onResizeStart": function () {},
+  "onResize": function () {},
+  "onResizeStop": function () {},
+  "placeholder": function () {},
+  "processGridItem": function () {},
+  "render": function () {},
+  "isReactComponent": function () {},
+  "setState": function () {},
+  "forceUpdate": function () {}
+};
+ReactGridLayout.Responsive.prototype = {
+  "generateInitialState": function () {},
+  "componentWillReceiveProps": function () {},
+  "onWidthChange": function () {},
+  "render": function () {},
+  "isReactComponent": function () {},
+  "setState": function () {},
+  "forceUpdate": function () {}
 };


### PR DESCRIPTION
#### What

Updates `react-grid-layout` to the latest release, `0.12.3`. Requires an upgrade of react to `15.0.2`.

**Note:**  Auto-generated a new externs file and placed the directions that I used to generate it. I'm not quite sure how the previous externs was generated.