### PR TITLE
Adds bcrypt library version 2.3.0

### DIFF
--- a/bcrypt/README.md
+++ b/bcrypt/README.md
@@ -1,0 +1,23 @@
+# cljsjs/bcrypt
+
+[](dependency)
+```clojure
+[cljsjs/bcrypt "2.3.0-0"] ;; latest release
+```
+[](/dependency)
+
+This jar comes with `deps.cljs` as used by the [Foreign Libs][flibs] feature
+of the Clojurescript compiler. After adding the above dependency to your project
+you can require the packaged library like so:
+
+```clojure
+(ns application.core
+  (:require [cljsjs.bcrypt]))
+
+;; Somewhere in code
+
+(js/dcodeIO.bcrypt.hash ....)
+
+```
+
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies

--- a/bcrypt/build.boot
+++ b/bcrypt/build.boot
@@ -1,0 +1,33 @@
+(set-env!
+ :resource-paths #{"resources"}
+ :dependencies '[[cljsjs/boot-cljsjs "0.5.1" :scope "test"]])
+
+(require '[cljsjs.boot-cljsjs.packaging :refer :all])
+
+(def +lib-version+ "2.3.0")
+(def +version+ (str +lib-version+ "-0"))
+
+(task-options!
+ pom {:project     'cljsjs/bcrypt
+      :version     +version+
+      :description "Optimized bcrypt in JavaScript with zero dependencies"
+      :url         "https://github.com/dcodeIO/bcrypt.js"
+      :scm         {:url "https://github.com/dcodeIO/bcrypt.js"}
+      :license     {"New-BSD / MIT" "http://opensource.org/licenses/MIT"}})
+
+(deftask package []
+  (comp
+     (download :url (str "https://github.com/dcodeIO/bcrypt.js/archive/" +lib-version+ ".zip")
+               :checksum "5e7a43fa75522dcd27ef28cf3923329b"
+               :unzip true)
+
+     (sift :move {#"^bcrypt.js-(.*)/dist/bcrypt.js$" "cljsjs/bcrypt/development/bcrypt.inc.js"
+                  #"^bcrypt.js-(.*)/dist/bcrypt.min.js$" "cljsjs/bcrypt/production/bcrypt.min.inc.js"})
+
+     (sift :include #{#"^cljsjs"})
+
+     (deps-cljs :name "cljsjs.bcrypt")
+
+     (pom)
+
+     (jar)))

--- a/bcrypt/resources/cljsjs/bcrypt/common/bcrypt.ext.js
+++ b/bcrypt/resources/cljsjs/bcrypt/common/bcrypt.ext.js
@@ -1,0 +1,25 @@
+//
+// Provided by library https://raw.githubusercontent.com/dcodeIO/bcrypt.js/2.3.0/externs/bcrypt.js
+// Adjusted since it did not include the `dcodeIO` object reference
+
+var dcodeIO = {
+  "bcrypt": {}
+};
+
+dcodeIO.bcrypt.setRandomFallback = function(random) {};
+
+dcodeIO.bcrypt.genSaltSync = function(rounds, seed_length) {};
+
+dcodeIO.bcrypt.genSalt = function(rounds, seed_length, callback) {};
+
+dcodeIO.bcrypt.hashSync = function(s, salt) {};
+
+dcodeIO.bcrypt.hash = function(s, salt, callback) {};
+
+dcodeIO.bcrypt.compareSync = function(s, hash) {};
+
+dcodeIO.bcrypt.compare = function(s, hash, callback) {};
+
+dcodeIO.bcrypt.getRounds = function(hash) {};
+
+dcodeIO.bcrypt.getSalt = function(hash) {};


### PR DESCRIPTION
#### What

Adds `bcrypt` version 2.3.0 the latest tagged release.

Notes: The provided externs in the library itself seemed to be out of date. I updated it via a hand rolling but was tested with optimizations `:none` and `:advanced`. It exposes the lib thru js/dcodeIO so I added an example in the README.md about that.