### PR TITLE
Add lamejs package with build.boot, ext file and a README

### DIFF
--- a/lamejs/README.md
+++ b/lamejs/README.md
@@ -1,0 +1,26 @@
+# cljsjs/lamejs
+
+[](dependency)
+```clojure
+[cljsjs/lamejs "1.0.0-0"] ;; latest release
+```
+[](/dependency)
+
+This JAR comes with `deps.cljs`, as used by the [Foreign Libs][flibs]
+feature of the ClojureScript compiler. After adding the above dependency
+to your project, you can require the packaged `lamejs` library as
+follows:
+
+```clojure
+(ns application.core
+  (:require [cljsjs.lamejs]))
+
+;; Somewhere in your code
+
+(let [encoder (js/lamejs.Mp3Encoder. 1 44100 128)
+      samples (Int16Array. 44100)]
+  (.encodeBuffer encoder samples))
+```
+
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies
+

--- a/lamejs/build.boot
+++ b/lamejs/build.boot
@@ -1,0 +1,35 @@
+(set-env!
+  :resource-paths #{"resources"}
+  :dependencies '[[cljsjs/boot-cljsjs "0.5.1" :scope "test"]])
+
+(require '[cljsjs.boot-cljsjs.packaging :refer :all])
+
+(def +lib-version+ "1.1.0")
+(def +version+     (str +lib-version+ "-0"))
+(def +commit+      "e2e418c209caa7f36b9573a8f563425d2e285a57")
+
+(task-options!
+  push {:ensure-clean false}
+  pom  {:project      'cljsjs/lamejs
+        :version      +version+
+        :description  "Fast MP3 encoder written in JavaScript"
+        :url          "https://github.com/zhuker/lamejs"
+        :license      {"LGPL-3.0" "https://opensource.org/licenses/LGPL-3.0"}
+        :scm          {:url "https://github.com/zhuker/lamejs"}})
+
+(deftask package
+  []
+  (comp
+    (download
+      :url (format "https://github.com/zhuker/lamejs/archive/%s.zip"
+                   +commit+)
+      :checksum "69BB29E1739C24666D95FFF71E985FA2"
+      :unzip true)
+    (sift :move {#"^lamejs-[^\/]*/lame.all.js"
+                 "cljsjs/development/lame.inc.js"
+                 #"^lamejs-[^\/]*/lame.min.js"
+                 "cljsjs/production/lame.min.inc.js"})
+    (sift :include #{#"^cljsjs"})
+    (deps-cljs :name "cljsjs.lamejs")
+    (pom)
+    (jar)))

--- a/lamejs/resources/cljsjs/lamejs/common/lamejs.ext.js
+++ b/lamejs/resources/cljsjs/lamejs/common/lamejs.ext.js
@@ -1,0 +1,5 @@
+var lamejs = {};
+
+lamejs.Mp3Encoder = function (channels, samplerate, kbps) {};
+
+lamejs.WavHeader = function () {};


### PR DESCRIPTION
This adds a `cljsjs.lamejs` package for a fast MP3 encoder written purely in JavaScript.