### PR TITLE
fix library require name

### DIFF
--- a/autobahnjs/README.md
+++ b/autobahnjs/README.md
@@ -14,7 +14,7 @@ you can require the packaged library like so:
 
 ```clojure
 (ns your-ns
-  (:require [cljsjs.autobahnjs]))
+  (:require [cljsjs.autobahn]))
              
 (def ^:private ab js/autobahn)
 


### PR DESCRIPTION
Took me a while to figure out why I was getting `no such namespace` issues. The README.md is just wrong.