### PR TITLE
[material-ui] add react-dom and react-dom-server to bundled react

### DIFF
--- a/material-ui/README.md
+++ b/material-ui/README.md
@@ -4,7 +4,7 @@ http://www.material-ui.com/#/
 
 [](dependency)
 ```clojure
-[cljsjs/material-ui "0.15.0-3"] ;; latest release
+[cljsjs/material-ui "0.15.0-4"] ;; latest release
 ```
 [](/dependency)
 

--- a/material-ui/build.boot
+++ b/material-ui/build.boot
@@ -9,7 +9,7 @@
          '[boot.util :refer [sh]])
 
 (def +lib-version+ "0.15.0")
-(def +version+ (str +lib-version+ "-3"))
+(def +version+ (str +lib-version+ "-4"))
 (def +lib-folder+ (format "material-ui-%s" +lib-version+))
 
 (task-options!

--- a/material-ui/resources/cljsjs/material-ui/common/react-dom-server.ext.js
+++ b/material-ui/resources/cljsjs/material-ui/common/react-dom-server.ext.js
@@ -1,0 +1,42 @@
+/**
+ * @fileoverview Closure Compiler externs for Facebook ReactDOMServer.js DOM 0.14.0
+ * @see http://reactjs.org
+ * @externs
+ */
+
+/**
+ * The ReactDOMServer global object.
+ *
+ * @type {!Object}
+ * @const
+ */
+var ReactDOMServer = {};
+
+
+/**
+ * The current version of ReactDOMServer.
+ *
+ * @type {string}
+ * @const
+ */
+ReactDOMServer.version;
+
+/**
+ * Render a ReactElement to its initial HTML.
+ *
+ * @param {React.ReactElement} element
+ * @return {string}
+ */
+ReactDOMServer.renderToString = function(element) {};
+
+
+/**
+ * Similar to renderToString, except this doesn't create extra DOM attributes
+ * such as data-react-id, that React uses internally. This is useful if you want
+ * to use React as a simple static page generator, as stripping away the extra
+ * attributes can save lots of bytes.
+ *
+ * @param {React.ReactElement} element
+ * @return {string}
+ */
+ReactDOMServer.renderToStaticMarkup = function(element) {};

--- a/material-ui/resources/cljsjs/material-ui/common/react-dom.ext.js
+++ b/material-ui/resources/cljsjs/material-ui/common/react-dom.ext.js
@@ -1,0 +1,76 @@
+/**
+ * @fileoverview Closure Compiler externs for Facebook ReactDOM.js DOM 0.14.0
+ * @see http://reactjs.org
+ * @externs
+ */
+
+
+/**
+ * The ReactDOM global object.
+ *
+ * @type {!Object}
+ * @const
+ */
+var ReactDOM = {};
+
+
+/**
+ * The current version of ReactDOM.
+ *
+ * @type {string}
+ * @const
+ */
+ReactDOM.version;
+
+
+/**
+ * @param {React.ReactComponent} container
+ * @param {Element} mountPoint
+ * @param {Function=} callback
+ * @return {React.ReactComponent}
+ */
+ReactDOM.render = function(container, mountPoint, opt_callback) {};
+
+
+/**
+ * @param {Element} container
+ * @return {boolean}
+ */
+ReactDOM.unmountComponentAtNode = function(container) {};
+
+
+/**
+ * @param {React.ReactComponent} component
+ * @return {Element}
+ */
+ReactDOM.findDOMNode = function(component) {};
+
+
+/**
+ * Call the provided function in a context within which calls to `setState`
+ * and friends are batched such that components aren't updated unnecessarily.
+ *
+ * @param {Function} callback Function which calls `setState`, `forceUpdate`, etc.
+ * @param {*=} opt_a Optional argument to pass to the callback.
+ * @param {*=} opt_b Optional argument to pass to the callback.
+ * @param {*=} opt_c Optional argument to pass to the callback.
+ * @param {*=} opt_d Optional argument to pass to the callback.
+ * @param {*=} opt_e Optional argument to pass to the callback.
+ * @param {*=} opt_f Optional argument to pass to the callback.
+ */
+ReactDOM.unstable_batchedUpdates = function(callback, opt_a, opt_b, opt_c, opt_d, opt_e) {};
+
+/**
+ * Renders a React component into the DOM in the supplied `container`.
+ *
+ * If the React component was previously rendered into `container`, this will
+ * perform an update on it and only mutate the DOM as necessary to reflect the
+ * latest React component.
+ *
+ * @param {React.ReactComponent} parentComponent The conceptual parent of this render tree.
+ * @param {React.ReactElement} nextElement Component element to render.
+ * @param {Element} container DOM element to render into.
+ * @param {Function=} callback function triggered on completion
+ * @return {React.ReactComponent} Component instance rendered in `container`.
+ */
+ReactDOM.unstable_renderSubtreeIntoContainer = function(parentComponent, nextElement, container, opt_callback) {};

--- a/material-ui/resources/deps.cljs
+++ b/material-ui/resources/deps.cljs
@@ -1,10 +1,12 @@
 {:foreign-libs [{:file     "cljsjs/material-ui/development/material-ui.inc.js",
-                 :provides ["cljsjs.react" "cljsjs.material-ui"],
+                 :provides ["cljsjs.react" "cljsjs.react.dom" "cljsjs.material-ui"],
                  :file-min "cljsjs/material-ui/production/material-ui.min.inc.js"}
                 {:file     "cljsjs/material-ui/development/material-ui-svg-icons.inc.js",
                  :provides ["cljsjs.material-ui-svg-icons"],
                  :requires ["cljsjs.material-ui"],
                  :file-min "cljsjs/material-ui/production/material-ui-svg-icons.min.inc.js"}],
  :externs      ["cljsjs/material-ui/common/react.ext.js"
+                "cljsjs/material-ui/common/react-dom.ext.js"
+                "cljsjs/material-ui/common/react-dom-server.ext.js"
                 "cljsjs/material-ui/common/material-ui.ext.js"
                 "cljsjs/material-ui/common/material-ui-svg-icons.ext.js"]}

--- a/material-ui/resources/main.js
+++ b/material-ui/resources/main.js
@@ -1,11 +1,15 @@
 (function () {
 
-  var React = require('react/lib/ReactUMDEntry');
+  var React = require('react');
+  var ReactDOM = require('react-dom');
+  var ReactDOMServer = require('react-dom/server');
   var injectTapEventPlugin = require("react-tap-event-plugin");
   var materialUI = require('./build/index.js');
   var materialUIStyles = require('./build/styles/index.js');
 
   window["React"] = React;
+  window["ReactDOM"] = ReactDOM;
+  window["ReactDOMServer"] = ReactDOMServer;
   window["MaterialUI"] = materialUI;
   window["MaterialUIStyles"] = materialUIStyles;
 


### PR DESCRIPTION
Various packages (like sablono) need `cljsjs.react.dom` along with `js/ReactDOM` and `js/ReactDOMServer`.
This PR adds support for those. It shouldn't make a difference in filesize, as that code is in react anyways.

cc @madvas 