### PR TITLE
[c3] Update c3 to 0.4.11

### DIFF
--- a/c3/README.md
+++ b/c3/README.md
@@ -2,7 +2,7 @@
 
 [](dependency)
 ```clojure
-[cljsjs/c3 "0.4.10-0"] ;; latest release
+[cljsjs/c3 "0.4.11-0"] ;; latest release
 ```
 [](/dependency)
 

--- a/c3/build.boot
+++ b/c3/build.boot
@@ -5,7 +5,7 @@
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
-(def +lib-version+ "0.4.10")
+(def +lib-version+ "0.4.11")
 (def +version+ (str +lib-version+ "-0"))
 
 (task-options!
@@ -19,7 +19,7 @@
 (deftask package []
   (comp
    (download :url      (str "https://github.com/masayuki0812/c3/archive/" +lib-version+ ".zip")
-             :checksum "86E26485D03248E7D989B4FBD8A63ECD"
+             :checksum "9F20F238498DF31BCF7D0BAD2FABD293"
              :unzip    true)
    (sift :move {#"^c3-([\d\.]*)/c3\.js"      "cljsjs/c3/development/c3.inc.js"
                 #"^c3-([\d\.]*)/c3\.min\.js" "cljsjs/c3/production/c3.min.inc.js"


### PR DESCRIPTION
This updates c3 to version [0.4.11](https://github.com/c3js/c3/releases/tag/0.4.11).