### PR TITLE
downgrade to 0.6.1 until VictoryLine gets fixed

### DIFF
--- a/victory/build.boot
+++ b/victory/build.boot
@@ -5,7 +5,7 @@
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
-(def +lib-version+ "0.8.0")
+(def +lib-version+ "0.6.1")
 (def +version+ (str +lib-version+ "-0"))
 
 (task-options!
@@ -19,7 +19,7 @@
 (deftask package []
   (comp
     (download :url (format "https://github.com/FormidableLabs/victory/archive/v%s.zip" +lib-version+)
-              :checksum "E773BC66CF093065773D1120E5B4777A"
+              :checksum "301569CD68FC91183B07EA358AB1575B"
               :unzip true)
     (sift :move { #"^victory-.*/dist/victory\.js$"      "cljsjs/victory/development/victory.inc.js"
                   #"^victory-.*/dist/victory\.min\.js$" "cljsjs/victory/production/victory.min.inc.js" })

--- a/victory/resources/cljsjs/common/victory.ext.js
+++ b/victory/resources/cljsjs/common/victory.ext.js
@@ -1,4 +1,11 @@
 // List manually adapted from https://github.com/FormidableLabs/victory/blob/master/src/index.js
+//
+// As of this writing, the latest version is 0.8.0, but VictoryLine won't work
+// for any version after 0.6.1, so we stick with this version until that's
+// fixed.
+//
+// This list should be good for a 0.7.0 release, should you want to make it. For
+// 0.8.0 or later, the VictorySharedEvents entry should be uncommented at least.
 
 var Victory = {
   "VictoryAnimation": function() {},
@@ -11,7 +18,7 @@ var Victory = {
   "VictoryLine": function() {},
   "VictoryPie": function() {},
   "VictoryScatter": function() {},
-  "VictorySharedEvents": function() {},
+//  "VictorySharedEvents": function() {},
   "VictoryStack": function() {},
   "VictoryTransition": function() {}
 }


### PR DESCRIPTION
VictoryLine is broken in 0.7.0 and 0.8.0.  Lacking the ability to plot lines would be more crippling than missing anything in these newer versions.

It seems that the only new extern since 0.6.1 is `VictorySharedEvents`, so I've commented out its entry for the time being.

```diff
es@bocha:~/src/victory/src$ git diff v0.6.1 -- index.js
diff --git a/src/index.js b/src/index.js
index 3313e5c..8b24dbb 100644
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,8 @@
 import {
   VictoryAnimation,
   VictoryLabel,
-  VictoryTransition
+  VictoryTransition,
+  VictorySharedEvents
 } from "victory-core";
 
 import {
@@ -29,5 +30,6 @@ export {
   VictoryPie,
   VictoryScatter,
   VictoryStack,
-  VictoryTransition
+  VictoryTransition,
+  VictorySharedEvents
 };
```