### PR TITLE
upgrade victory.js to v0.9.0

### DIFF
--- a/victory/build.boot
+++ b/victory/build.boot
@@ -5,7 +5,7 @@
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
-(def +lib-version+ "0.6.1")
+(def +lib-version+ "0.9.0")
 (def +version+ (str +lib-version+ "-0"))
 
 (task-options!
@@ -19,7 +19,7 @@
 (deftask package []
   (comp
     (download :url (format "https://github.com/FormidableLabs/victory/archive/v%s.zip" +lib-version+)
-              :checksum "301569CD68FC91183B07EA358AB1575B"
+              :checksum "2CD9F59057250A86458A554E3D7E5D51"
               :unzip true)
     (sift :move { #"^victory-.*/dist/victory\.js$"      "cljsjs/victory/development/victory.inc.js"
                   #"^victory-.*/dist/victory\.min\.js$" "cljsjs/victory/production/victory.min.inc.js" })

--- a/victory/resources/cljsjs/common/victory.ext.js
+++ b/victory/resources/cljsjs/common/victory.ext.js
@@ -1,11 +1,4 @@
 // List manually adapted from https://github.com/FormidableLabs/victory/blob/master/src/index.js
-//
-// As of this writing, the latest version is 0.8.0, but VictoryLine won't work
-// for any version after 0.6.1, so we stick with this version until that's
-// fixed.
-//
-// This list should be good for a 0.7.0 release, should you want to make it. For
-// 0.8.0 or later, the VictorySharedEvents entry should be uncommented at least.
 
 var Victory = {
   "VictoryAnimation": function() {},
@@ -13,12 +6,13 @@ var Victory = {
   "VictoryAxis": function() {},
   "VictoryBar": function() {},
   "VictoryChart": function() {},
+  "VictoryContainer": function() {},
   "VictoryGroup": function() {},
   "VictoryLabel": function() {},
   "VictoryLine": function() {},
   "VictoryPie": function() {},
   "VictoryScatter": function() {},
-//  "VictorySharedEvents": function() {},
+  "VictorySharedEvents": function() {},
   "VictoryStack": function() {},
   "VictoryTransition": function() {}
 }


### PR DESCRIPTION
This version fixes the problem with VictoryLine which had us pinning this library to v0.6.1.

Update:

**Extern:** I updated the extern by hand.

