### PR TITLE
aws-sdk-js: Fix production aws-sdk.min.js path

### DIFF
--- a/aws-sdk-js/build.boot
+++ b/aws-sdk-js/build.boot
@@ -30,7 +30,7 @@
              :unzip true)
 
    (sift :move {#"^aws-sdk-js-.*/dist/aws-sdk.js"  "cljsjs/aws-sdk-js/development/aws-sdk-js.inc.js"
-                #"^aws-sdk-js-.*/dist/aws-sdk-min.js"  "cljsjs/aws-sdk-js/production/aws-sdk-js-min.inc.js"})
+                #"^aws-sdk-js-.*/dist/aws-sdk.min.js"  "cljsjs/aws-sdk-js/production/aws-sdk-js.min.inc.js"})
 
    (sift :include #{#"^cljsjs"})
 

--- a/aws-sdk-js/build.boot
+++ b/aws-sdk-js/build.boot
@@ -7,7 +7,7 @@
 
 
 (def +lib-version+ "2.2.41")
-(def +version+ (str +lib-version+ "-0"))
+(def +version+ (str +lib-version+ "-1"))
 
 (task-options!
   push {:ensure-clean false}


### PR DESCRIPTION
The production path for aws-sdk-js.min.js has a hyphen where there should be a dot, and as a result there is no production folder in the release.