### PR TITLE
[typeahead-bundle] Add dependency on jquery

### DIFF
--- a/typeahead-bundle/build.boot
+++ b/typeahead-bundle/build.boot
@@ -1,11 +1,12 @@
 (set-env!
  :resource-paths #{"resources"}
- :dependencies '[[cljsjs/boot-cljsjs "0.5.2" :scope "test"]])
+ :dependencies '[[cljsjs/boot-cljsjs "0.5.2" :scope "test"]
+                 [cljsjs/jquery "1.9.1-0"]])
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
 (def +lib-version+ "0.11.1")
-(def +version+ (str +lib-version+ "-1"))
+(def +version+ (str +lib-version+ "-2"))
 
 (task-options!
  pom  {:project     'cljsjs/typeahead-bundle
@@ -22,6 +23,7 @@
    (sift :move {#".*?typeahead.bundle.js"     "cljsjs/typeahead-bundle/development/typeahead.inc.js"
                 #".*?typeahead.bundle.min.js" "cljsjs/typeahead-bundle/production/typeahead.bundle.min.inc.js"})
    (sift :include #{#"^cljsjs"})
-   (deps-cljs :name "cljsjs.typeahead-bundle")
+   (deps-cljs :name "cljsjs.typeahead-bundle"
+              :requires ["cljsjs.jquery"])
    (pom)
    (jar)))


### PR DESCRIPTION
Update:

**Extern:** The API did not change.
**Dependencies:** added dependency on jQuery.

Typeahead depends on jQuery. If the dependency declaration is missing in the package, typeahead might break because it gets loaded before jQuery.