### PR TITLE
[vega] Update to 2.6.0

### DIFF
--- a/vega/README.md
+++ b/vega/README.md
@@ -2,7 +2,7 @@
 
 [](dependency)
 ```clojure
-[cljsjs/vega "2.5.0-1"] ;; latest release
+[cljsjs/vega "2.6.0-0"] ;; latest release
 ```
 [](/dependency)
 

--- a/vega/build.boot
+++ b/vega/build.boot
@@ -1,12 +1,12 @@
 (set-env!
   :resource-paths #{"resources"}
   :dependencies '[[cljsjs/boot-cljsjs "0.5.2" :scope "test"]
-                  [cljsjs/d3 "3.5.7-0"]])
+                  [cljsjs/d3 "3.5.16-0"]])
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
-(def +lib-version+ "2.5.0")
-(def +version+ (str +lib-version+ "-1"))
+(def +lib-version+ "2.6.0")
+(def +version+ (str +lib-version+ "-0"))
 
 (task-options!
   pom {:project     'cljsjs/vega
@@ -21,7 +21,7 @@
     (download
       :url (str "https://github.com/vega/vega/archive/v" +lib-version+ ".zip")
       :unzip true
-      :checksum "5AFB54BE6EBACB09A8EC84432F28E791")
+      :checksum "801A8ACD07A61074B03AC0FBDCA6E12C")
     (sift :move {(re-pattern (str "^vega-" +lib-version+ "/vega.js$")) "cljsjs/development/vega.inc.js"
                  (re-pattern (str "^vega-" +lib-version+ "/vega.min.js$")) "cljsjs/production/vega.min.inc.js"})
     (sift :include #{#"^cljsjs"})

--- a/vega/resources/cljsjs/common/vega.ext.js
+++ b/vega/resources/cljsjs/common/vega.ext.js
@@ -1,3 +1,5 @@
+// Hand-crafted from <https://github.com/vega/vega/wiki/Runtime>
+
 var vg = {};
 vg.View.prototype = {}
 vg.View.prototype.width = function () {};
@@ -6,11 +8,14 @@ vg.View.prototype.padding = function () {};
 vg.View.prototype.viewport = function () {};
 vg.View.prototype.renderer = function () {};
 vg.View.prototype.data = function () {};
+vg.View.prototype.signal = function () {};
 vg.View.prototype.initialize = function () {};
 vg.View.prototype.render = function () {};
 vg.View.prototype.update = function () {};
 vg.View.prototype.on = function () {};
 vg.View.prototype.off = function () {};
+vg.View.prototype.onSignal = function () {};
+vg.View.prototype.offSignal = function () {};
 vg.View.prototype.toImageUrl = function () {};
 
 /**


### PR DESCRIPTION
Update:

**Extern:** The API did not change.
**Extern:** I updated the extern by hand.

As far as I can tell, the API did not actually change with this release, but the externs file for the previously packaged version was already out-of-date.