### PR TITLE
[pdf.js] Update to release 1.5.188

### DIFF
--- a/pdfjs/README.md
+++ b/pdfjs/README.md
@@ -2,7 +2,7 @@
 
 [](dependency)
 ```clojure
-[cljsjs/pdfjs "1.1.3-0"] ;; latest release
+[cljsjs/pdfjs "1.5.188-0"] ;; latest release
 ```
 [](/dependency)
 

--- a/pdfjs/build.boot
+++ b/pdfjs/build.boot
@@ -4,7 +4,7 @@
 
 (require '[cljsjs.boot-cljsjs.packaging :refer [download]])
 
-(def +lib-version+ "1.1.3")
+(def +lib-version+ "1.5.188")
 (def +version+ (str +lib-version+ "-0"))
 
 (task-options!
@@ -18,7 +18,7 @@
 (deftask package []
   (comp
     (download :url (format "https://github.com/mozilla/pdf.js/releases/download/v%s/pdfjs-%s-dist.zip" +lib-version+ +lib-version+)
-              :checksum "E25EE439EDC685D83C2D093CEC964A32"
+              :checksum "8646FE88211233E120C28613483D095C"
               :unzip true)
     (sift :move {#"^build/pdf\.js$"         "cljsjs/pdfjs/common/pdf.inc.js"
                  #"^build/pdf\.worker\.js$" "cljsjs/pdfjs/common/pdf.worker.inc.js"

--- a/pdfjs/resources/cljsjs/pdfjs/common/pdf.ext.js
+++ b/pdfjs/resources/cljsjs/pdfjs/common/pdf.ext.js
@@ -1,3 +1,11 @@
+// Generated via http://www.dotnetwise.com/Code/Externs/
+// One difference - the auto-generator marks workerSrc as a function, but it appears to be confused
+// Explicitly defined in pdf.js as @var {string}
+
+// Loaded JavaScripts:
+// pdf.js from https://github.com/mozilla/pdf.js/releases/tag/v1.5.188
+
+
 var PDFJS = {
     "version": {},
     "build": {},
@@ -128,6 +136,7 @@ var PDFJS = {
     "createPromiseCapability": function () {},
     "createBlob": function () {},
     "createObjectURL": function () {},
+    "removeNullCharacters": function () {},
     "maxImageSize": {},
     "cMapUrl": function () {},
     "cMapPacked": {},
@@ -145,22 +154,33 @@ var PDFJS = {
     "useOnlyCssZoom": {},
     "verbosity": {},
     "maxCanvasPixels": {},
+    "externalLinkTarget": {},
+    "externalLinkRel": {},
+    "isEvalSupported": {},
     "openExternalLinksInNewWindow": {},
     "getDocument": function () {},
-    "getPage": function () {},
-    "getViewport": function () {},
-    "then": function () {},
-    "cancel": function () {},
     "PDFDataRangeTransport": function () {},
+    "PDFWorker": function () {},
+    "CustomStyle": function () {},
+    "LinkTarget": {
+        "NONE": {},
+        "SELF": {},
+        "BLANK": {},
+        "PARENT": {},
+        "TOP": {}
+    },
+    "addLinkAttributes": function () {},
+    "getFilenameFromUrl": function () {},
+    "isExternalLinkTargetSet": function () {},
+    "AnnotationLayer": {
+        "render": function () {},
+        "update": function () {}
+    },
+    "renderTextLayer": function () {},
     "Metadata": function () {},
-    "AnnotationUtils": {
-        "getHtmlElement": function () {}
-    },
     "SVGGraphics": function () {},
-    "PDFPageView": {
-        "setPdfPage": function () {},
-        "update": function () {},
-        "draw": function () {}
-    },
-    "DefaultTextLayerFactory": {}
+    "disableHistory": {},
+    "disableTextLayer": {},
+    "ignoreCurrentPositionOnZoom": {},
+    "locale": {}
 };


### PR DESCRIPTION
**Extern:** I updated the extern with generator.

A couple of manual adjustments to re-order entries so the diff isn't so scary, and to correct workerSrc attribute which the generator mistakenly classed as a fn.

This also removes a number of externs. These weren't exposed in 1.1.3 nor are they in current 1.5.188, so they seem to have been mistakenly added. The then/cancel/getPage/getViewport properties are to the promise returned from .getDocument; not from pdfjs per se. AnnotationUtils/DefaultTextLayerFactory seems to come from viewer.js, not exported in the dist pdf.js.