### PR TITLE
[pickadate] Prefix pickadate css files with "pickadate"

### DIFF
--- a/pickadate/build.boot
+++ b/pickadate/build.boot
@@ -6,7 +6,7 @@
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
 (def +lib-version+ "3.5.6")
-(def +version+ (str +lib-version+ "-0"))
+(def +version+ (str +lib-version+ "-1"))
 
 (task-options!
   pom {:project 'cljsjs/pickadate
@@ -21,11 +21,11 @@
     (download :url (str "https://github.com/amsul/pickadate.js/archive/" +lib-version+ ".zip")
       :checksum "3AD8AF80E2974F7B5878DD14FA223649"
       :unzip true)
-    (sift :move {#"^pickadate.+/themes-source/(.+)\.less$"    "cljsjs/pickadate/development/$1.inc.less"
-                 #"^pickadate.+/compressed/themes/(.+)\.css$" "cljsjs/pickadate/production/$1.min.inc.css"
-                 #"^pickadate.+/themes/(.+)\.css$"            "cljsjs/pickadate/development/$1.inc.css"
-                 #"^pickadate.+/compressed/([^/]+)\.js$"       "cljsjs/pickadate/production/$1.min.inc.js"
-                 #"^pickadate.+/lib/([^/]+)\.js$"                "cljsjs/pickadate/development/$1.inc.js"})
+    (sift :move {#"^pickadate.+/themes-source/(.+)\.less$"    "cljsjs/pickadate/development/pickadate-$1.inc.less"
+                 #"^pickadate.+/compressed/themes/(.+)\.css$" "cljsjs/pickadate/production/pickadate-$1.min.inc.css"
+                 #"^pickadate.+/themes/(.+)\.css$"            "cljsjs/pickadate/development/pickadate-$1.inc.css"
+                 #"^pickadate.+/compressed/([^/]+)\.js$"      "cljsjs/pickadate/production/$1.min.inc.js"
+                 #"^pickadate.+/lib/([^/]+)\.js$"             "cljsjs/pickadate/development/$1.inc.js"})
     (sift :include #{#"^cljsjs/" #"^deps.cljs$"})
     (pom)
     (jar)))


### PR DESCRIPTION
I realized that the css files included for pickadate where just labelled
"classic.css" and "default.css", which wasn't descriptive names for the files.