### PR TITLE
Fix compiler warnings

### DIFF
--- a/msgpack-js-browser/build.boot
+++ b/msgpack-js-browser/build.boot
@@ -1,5 +1,5 @@
 (def +lib-version+ "0.1.4")
-(def +version+ (str +lib-version+ "-0"))
+(def +version+ (str +lib-version+ "-1"))
 
 (set-env!
  :resource-paths #{"resources"}

--- a/msgpack-js-browser/resources/cljsjs/msgpack-js-browser/common/msgpack-js-browser.ext.js
+++ b/msgpack-js-browser/resources/cljsjs/msgpack-js-browser/common/msgpack-js-browser.ext.js
@@ -1,3 +1,3 @@
-msgpack = {};
+var msgpack = {};
 msgpack.encode = function(){};
 msgpack.decode = function(){};


### PR DESCRIPTION
I missed `var` causing syntax warnings in advanced compilation mode.

Update:

**Extern:** The API did not change.
**Extern:** I updated the extern by hand.
