### PR TITLE
[react-burger-menu] update to v1.9.9

### DIFF
--- a/react-burger-menu/build.boot
+++ b/react-burger-menu/build.boot
@@ -1,12 +1,13 @@
 (set-env!
   :resource-paths #{"resources"}
   :dependencies '[[cljsjs/boot-cljsjs "0.5.2"  :scope "test"]
-                  [cljsjs/react       "0.13.3-0"]
+                  [cljsjs/react       "15.3.0-0"]
+                  [cljsjs/radium      "0.17.1-0"]
                   [cljsjs/snapsvg     "0.4.1-0"]])
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
-(def +lib-version+ "1.1.6")
+(def +lib-version+ "1.9.9")
 (def +version+ (str +lib-version+ "-0"))
 
 (task-options!
@@ -18,8 +19,8 @@
        :license     {"MIT" "http://opensource.org/licenses/MIT"}})
 
 (deftask download-react-burger-menu []
-  (download :url      (str "https://github.com/negomi/react-burger-menu/archive/" +lib-version+ ".zip")
-            :checksum "a113cce4af93dc0c18034b9589b38ccc"
+  (download :url      (str "https://github.com/negomi/react-burger-menu/archive/v" +lib-version+ ".zip")
+            :checksum "12ac86125106d7c178f7934cf9cd09e9"
             :unzip    true))
 
 (deftask package []
@@ -31,6 +32,6 @@
                  "cljsjs/react-burger-menu/production/react-burger-menu.min.inc.js"})
     (sift :include #{#"^cljsjs"})
     (deps-cljs :name "cljsjs.react-burger-menu"
-               :requires ["cljsjs.react" "cljsjs.snapsvg"])
+               :requires ["cljsjs.react" "cljsjs.radium" "cljsjs.snapsvg"])
     (pom)
     (jar)))


### PR DESCRIPTION
Update:

**Extern:** The API did not change.

Not bumping all the way to latest v1.10.2 since that now depends on snapsvg-cjs which is a re-packaging of snapsvg & I think that violates the "no package against forks".

The radium dependency is now required at runtime.