### PR TITLE
[react-onclickoutside] Add missing dependency

### DIFF
--- a/react-onclickoutside/build.boot
+++ b/react-onclickoutside/build.boot
@@ -1,9 +1,10 @@
 (def +lib-version+ "4.9.0")
-(def +version+ (str +lib-version+ "-0"))
+(def +version+ (str +lib-version+ "-1"))
 
 (set-env!
   :resource-paths #{"resources"}
   :dependencies '[[cljsjs/boot-cljsjs "0.5.2" :scope "test"]
+                  [cljsjs/object-assign-shim "0.1.0-0"]
                   [cljsjs/react "15.3.0-0"]])
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])


### PR DESCRIPTION
I referenced `cljsjs.object-assign-shim` in the deps-cljs, but did not include it in the actual dependencies at the top of the file. This should fix the bug reported in slack with the react-datepicker version 0.28.2 where someone had to manually include `[cljsjs/object-assign-shim "0.1.0-0"]` to use that version

Update:

**Extern:** The API did not change.

