### PR TITLE
react-input-mask, raven

### DIFF
--- a/raven/build.boot
+++ b/raven/build.boot
@@ -4,7 +4,7 @@
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
-(def +lib-version+ "2.1.0")
+(def +lib-version+ "3.5.1")
 (def +version+ (str +lib-version+ "-0"))
 
 (task-options!
@@ -18,7 +18,7 @@
 (deftask package []
   (comp
     (download :url (format "https://github.com/getsentry/raven-js/archive/%s.zip" +lib-version+)
-              :checksum "f2024a0c32c2557df8b709371a77554a"
+              :checksum "0aa05801b31f2787167ecc1770564161"
               :unzip true)
     (sift :move { #"^raven-js.*/dist/raven\.js$"      "cljsjs/raven/development/raven.inc.js"
                   #"^raven-js.*/dist/raven\.min\.js$" "cljsjs/raven/production/raven.min.inc.js" })

--- a/raven/resources/cljsjs/raven/common/raven.ext.js
+++ b/raven/resources/cljsjs/raven/common/raven.ext.js
@@ -16,7 +16,11 @@ var Raven = {
     "crossOrigin": {},
     "collectWindowErrors": {},
     "maxMessageLength": {},
-    "stackTraceLimit": {}
+    "stackTraceLimit": {},
+    "transport": {},
+    "allowSecretKey": {},
+    "enviroment": {},
+    "release": {}
   },
   "_ignoreOnError": {},
   "_isRavenInstalled": {},
@@ -84,6 +88,7 @@ var Raven = {
   "setTagsContext": function () {},
   "clearContext": function () {},
   "getContext": function () {},
+  "setEnvironment": function() {},
   "setRelease": function () {},
   "setDataCallback": function () {},
   "setShouldSendCallback": function () {},

--- a/react-input-mask/README.md
+++ b/react-input-mask/README.md
@@ -2,7 +2,7 @@
 
 [](dependency)
 ```clojure
-[cljsjs/react-input-mask "0.6.2-0"] ;; latest release
+[cljsjs/react-input-mask "0.7.2-0"] ;; latest release
 ```
 [](/dependency)
 

--- a/react-input-mask/build.boot
+++ b/react-input-mask/build.boot
@@ -1,11 +1,11 @@
 (set-env!
   :resource-paths #{"resources"}
   :dependencies '[[cljsjs/boot-cljsjs "0.5.2"  :scope "test"]
-                  [cljsjs/react "0.14.3-0"]])
+                  [cljsjs/react "15.3.0-0"]])
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
-(def +lib-version+ "0.6.2")
+(def +lib-version+ "0.7.2")
 (def +version+ (str +lib-version+ "-0"))
 
 (task-options!
@@ -23,8 +23,8 @@
 
 (deftask package []
   (comp
-    (download :url "https://raw.githubusercontent.com/sanniassin/react-input-mask/0.6.2/build/InputElement.js"
-              :checksum "75D0299C71420641A8503F3ED4383835")
+    (download :url "https://raw.githubusercontent.com/sanniassin/react-input-mask/0.7.2/build/InputElement.js"
+              :checksum "02A8811D99A7EA377C52CA061BA3D731")
 
     (replace-content :in "InputElement.js" :out "InputElement.js"
       :match #"var React = require.*;"


### PR DESCRIPTION
react-input-mask 0.7.2:

**Extern:** The API did not change.

raven 3.5.1:

**Extern:** Updated.