### PR TITLE
Add x0, x1, y0 and y1 accessors to d3.area object

### DIFF
--- a/d3/resources/cljsjs/d3/common/d3.ext.js
+++ b/d3/resources/cljsjs/d3/common/d3.ext.js
@@ -125,7 +125,12 @@ var d3 = {
   "quadtree": function () {},
   "queue": function () {},
   "arc": function () {},
-  "area": function () {},
+  "area": {
+    "y0": function(){},
+    "y1": function(){},
+    "x0": function(){},
+    "x1": function(){}
+  },
   "line": function () {},
   "pie": function () {},
   "radialArea": function () {},


### PR DESCRIPTION
**Extern:** I updated the extern by hand.

Issue #707 refers

I'm not sure I'm properly respecting the externs conventions here but happy to adjust if not.