### PR TITLE
[react-onclickoutside] Bump dep object-assign-shim

### DIFF
--- a/react-onclickoutside/README.md
+++ b/react-onclickoutside/README.md
@@ -2,7 +2,7 @@
 
 [](dependency)
 ```clojure
-[cljsjs/react-onclickoutside "4.9.0-1"] ;; latest release
+[cljsjs/react-onclickoutside "4.9.0-2"] ;; latest release
 ```
 [](/dependency)
 

--- a/react-onclickoutside/build.boot
+++ b/react-onclickoutside/build.boot
@@ -1,10 +1,10 @@
 (def +lib-version+ "4.9.0")
-(def +version+ (str +lib-version+ "-1"))
+(def +version+ (str +lib-version+ "-2"))
 
 (set-env!
   :resource-paths #{"resources"}
   :dependencies '[[cljsjs/boot-cljsjs "0.5.2" :scope "test"]
-                  [cljsjs/object-assign-shim "0.1.0-0"]
+                  [cljsjs/object-assign-shim "0.1.0-1"]
                   [cljsjs/react "15.3.0-0"]])
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])


### PR DESCRIPTION
Dependency `cljsjs/object-assign-shim` has two published versions on Clojars: [`0.1.0-0`](https://clojars.org/cljsjs/object-assign-shim/versions/0.1.0-0) and [`0.1.0-1`](https://clojars.org/cljsjs/object-assign-shim/versions/0.1.0-1).

As far as I can tell, looking at the content of the published jars, the only difference is that `0.1.0-1` inlcludes `deps.cljs`, where `0.1.0-0` does not.  Obviously it would be nice for `react-onclickoutside` to use the version which does have `deps.cljs` for all its automagical goodness.

Update:

**Extern:** The API did not change.
