### PR TITLE
[react-datepicker] Fix CSS generation

### DIFF
--- a/react-datepicker/README.md
+++ b/react-datepicker/README.md
@@ -2,7 +2,7 @@
 
 [](dependency)
 ```clojure
-[cljsjs/react-datepicker "0.28.2-1"] ;; latest release
+[cljsjs/react-datepicker "0.28.2-2"] ;; latest release
 ```
 [](/dependency)
 

--- a/react-datepicker/build.boot
+++ b/react-datepicker/build.boot
@@ -13,7 +13,7 @@
          '[boot.util :refer [sh]])
 
 (def +lib-version+ "0.28.2")
-(def +version+ (str +lib-version+ "-1"))
+(def +version+ (str +lib-version+ "-2"))
 
 (task-options!
  pom  {:project     'cljsjs/react-datepicker
@@ -43,7 +43,7 @@
         (io/make-parents target)
         (io/copy (tmpd/file f) target))
       (binding [boot.util/*sh-dir* (str (io/file tmp (format "react-datepicker-%s" +lib-version+)))]
-        ((sh "npm" "install" "--ignore-scripts"))
+        ((sh "npm" "install"))
         ((sh "gem" "install" "scss_lint"))
         ((sh "npm" "run" "build")))
       (-> fileset (boot/add-resource tmp) boot/commit!))))


### PR DESCRIPTION
Update:

**Extern:** The API did not change.

The `0.28.2-1` bundle doesn't include CSS, because the CSS-generating portion of the build fails, because the dependency used to generate it isn't properly installed.