### PR TITLE
Added simple example to three's README

### DIFF
--- a/three/README.md
+++ b/three/README.md
@@ -16,3 +16,48 @@ you can require the packaged library like so:
 ```
 
 [flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies
+
+#### Example: Simple spinning cube
+```clojure
+(ns minimal-cljs.core
+  (:require cljsjs.three))
+
+(defn init []
+
+  ;;First initiate the basic elements of a THREE scene
+  (let [scene    (js/THREE.Scene.)
+        p-camera (js/THREE.PerspectiveCamera.
+                    view-angle aspect near far)
+        box      (js/THREE.BoxGeometry.
+                    200 200 200)
+        mat      (js/THREE.MeshBasicMaterial.
+                    (js-obj "color" 0xff0000
+                            "wireframe" true))
+        mesh     (js/THREE.Mesh. box mat)
+        renderer (js/THREE.WebGLRenderer.)]
+
+    ;;Change the starting position of cube and camera
+    (aset p-camera "name" "p-camera")
+    (aset p-camera "position" "z" 500)
+    (aset mesh "rotation" "x" 45)
+    (aset mesh "rotation" "y" 0)
+    (.setSize renderer 500 500)
+
+    ;;Add camera, mesh and box to scene and then that to DOM node.
+    (.add scene p-camera)
+    (.add scene mesh)
+    (.appendChild js/document.body (.-domElement renderer))
+
+    ;Kick off the animation loop updating
+    (defn render []
+      (aset mesh "rotation" "y" (+ 0.01 (.-y (.-rotation mesh))))
+      (.render renderer scene p-camera))
+
+    (defn animate []
+      (.requestAnimationFrame js/window animate)
+      (render))
+
+    (animate)))
+
+(init)
+```


### PR DESCRIPTION
An example to make it easier for people looking at trying out THREE.js with clojurescript.  A lot of three users tend to come from more artsy backgrounds, and a little more documentation on the translation from one language to another might be helpful.

**Extern:** Provided by the library.

Update:

**Extern:** The API did not change.

