### PR TITLE
[object-assign-shim] Bump version to match Clojars

### DIFF
--- a/object-assign-shim/README.md
+++ b/object-assign-shim/README.md
@@ -2,7 +2,7 @@
 
 [](dependency)
 ```clojure
-[cljsjs/object-assign-shim "0.1.0-0"] ;; latest release
+[cljsjs/object-assign-shim "0.1.0-1"] ;; latest release
 ```
 [](/dependency)
 

--- a/object-assign-shim/build.boot
+++ b/object-assign-shim/build.boot
@@ -5,7 +5,7 @@
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
 (def +lib-version+ "0.1.0")
-(def +version+ (str +lib-version+ "-0"))
+(def +version+ (str +lib-version+ "-1"))
 
 (task-options!
  pom  {:project     'cljsjs/object-assign-shim


### PR DESCRIPTION
This version has already been deployed to Clojars, but the version number here in the repo never got updated.  There are no changes to the actual code, the only difference between `0.1.0-0` and `0.1.0-1` in Clojars is that the latter's artifact contains `deps.cljs`

Update:

**Extern:** The API did not change.
