### PR TITLE
[highstock] 4.2.2->4.2.6

### DIFF
--- a/highstock/build.boot
+++ b/highstock/build.boot
@@ -4,7 +4,7 @@
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
-(def +lib-version+ "4.2.2")
+(def +lib-version+ "4.2.6")
 (def +version+ (str +lib-version+ "-0"))
 
 (task-options!
@@ -17,10 +17,10 @@
 
 (deftask package []
   (comp
-   (download :url      (str "http://code.highcharts.com/stock/" +lib-version+ "/highstock.js")
-             :checksum "D3E8F95E1D92704E5B160C1759F1D662")
-   (download :url      (str "http://code.highcharts.com/stock/" +lib-version+ "/highstock.src.js")
-             :checksum "D955A1BA26D7D9B9204B10D4F72C2D23")
+   (download :url      (str "https://code.highcharts.com/stock/" +lib-version+ "/highstock.js")
+             :checksum "DCEDC903E6956F8766A9543524816331")
+   (download :url      (str "https://code.highcharts.com/stock/" +lib-version+ "/highstock.src.js")
+             :checksum "0AFAC63726D0E216BEF5FA56E3F98717")
    (sift :move {#"highstock.js"     "cljsjs/production/highstock.min.inc.js"})
    (sift :move {#"highstock.src.js"     "cljsjs/development/highstock.inc.js"})
    (sift :include #{#"^cljsjs"})

--- a/highstock/build.boot
+++ b/highstock/build.boot
@@ -17,14 +17,13 @@
 
 (deftask package []
   (comp
-   (download :url      (str "https://code.highcharts.com/stock/" +lib-version+ "/highstock.js")
+   (download :url (str "https://code.highcharts.com/stock/" +lib-version+ "/highstock.js")
              :checksum "DCEDC903E6956F8766A9543524816331")
-   (download :url      (str "https://code.highcharts.com/stock/" +lib-version+ "/highstock.src.js")
+   (download :url (str "https://code.highcharts.com/stock/" +lib-version+ "/highstock.src.js")
              :checksum "0AFAC63726D0E216BEF5FA56E3F98717")
    (sift :move {#"highstock.js"     "cljsjs/production/highstock.min.inc.js"})
-   (sift :move {#"highstock.src.js"     "cljsjs/development/highstock.inc.js"})
+   (sift :move {#"highstock.src.js" "cljsjs/development/highstock.inc.js"})
    (sift :include #{#"^cljsjs"})
-   (deps-cljs :name     "cljsjs.highstock"
-              :requires ["cljsjs.jquery"])
+   (deps-cljs :name "cljsjs.highstock")
    (pom)
    (jar)))

--- a/highstock/resources/cljsjs/common/highstock.ext.js
+++ b/highstock/resources/cljsjs/common/highstock.ext.js
@@ -1220,6 +1220,7 @@ Highcharts.Point.prototype = {
     "init": function () {},
     "applyOptions": function () {},
     "optionsToObject": function () {},
+    "dataGroup": function () {},
     "destroy": function () {},
     "destroyElements": function () {},
     "getLabelConfig": function () {},


### PR DESCRIPTION
Update:

**build.boot:**
Changed `:download` task from `http` to `https`.

**Extern:** 
One API item was added at `4.2.4` [changelog](http://www.highcharts.com/documentation/changelog#highstock)
I updated the extern by hand.

**Comments:**
Should we also update highcharts in unison? I took a look at the [changelog](http://www.highcharts.com/documentation/changelog) and there's quite a bit of additional configurations added, but those configs don't need to be listed in the externs file. 

One piece I wasn't quite sure about (relating to high*charts* not high*stock* is the `chart.events`. The existing externs file doesn't list anything related, so I'm not sure if it's not needed or it was missing the whole time. Perhaps @jimlar can comment?
