### PR TITLE
[react] Fix README typeo for minified TestUtils

### DIFF
--- a/react/README.md
+++ b/react/README.md
@@ -33,7 +33,7 @@ optimizations you'll need to override `:file-min` to use non-minified version. I
 ClojureScript compiler options, add:
 
 ```clj
-:foreign-libs [{:provides ["cljs.react"]
+:foreign-libs [{:provides ["cljsjs.react"]
                :file "cljsjs/development/react-with-addons.inc.js"
                :file-min "cljsjs/development/react-with-addons.inc.js"}]
 ```


### PR DESCRIPTION
Correct README for using react TestUtils with advanced optimization. The :provides value of the :foreign-libs declaration should match what's in deps.cljs.