### PR TITLE
Update Fuse to v2.5.0

### DIFF
--- a/fuse/README.md
+++ b/fuse/README.md
@@ -2,7 +2,7 @@
 
 [](dependency)
 ```clojure
-[cljsjs/fuse "2.2.0-0"] ;; latest release
+[cljsjs/fuse "2.5.0-0"] ;; latest release
 ```
 [](/dependency)
 

--- a/fuse/build.boot
+++ b/fuse/build.boot
@@ -4,7 +4,7 @@
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
-(def +lib-version+ "2.2.0")
+(def +lib-version+ "2.5.0")
 (def +version+ (str +lib-version+ "-0"))
 
 (task-options!
@@ -18,7 +18,7 @@
 (deftask package []
   (comp
    (download :url (str "https://github.com/krisk/Fuse/archive/v" +lib-version+ ".zip")
-             :checksum "7b4f646b8a31fac6e1af1445651adb90"
+             :checksum "E24A46DD222B363082A2655641818CA5"
              :unzip true)
    (sift :move {#"^Fuse-(.*)/src/fuse.js" "cljsjs/fuse/development/fuse.inc.js"
                 #"^Fuse-(.*)/src/fuse.min.js" "cljsjs/fuse/production/fuse.min.inc.js"})


### PR DESCRIPTION
Keep relevant lines. You should select one choice for each category
(e.g. Extern), if none of choices is valid you should probably do
something or at least add a comment here.

Update:
Extern: The API did not change.

Thanks,
Ryan