### PR TITLE
Fix bootstrap-toggle externs

### DIFF
--- a/bootstrap-toggle/README.md
+++ b/bootstrap-toggle/README.md
@@ -2,7 +2,7 @@
 
 [](dependency)
 ```clojure
-[cljsjs/bootstrap-toggle "2.2.2-0"] ;; latest release
+[cljsjs/bootstrap-toggle "2.2.2-1"] ;; latest release
 ```
 [](/dependency)
 

--- a/bootstrap-toggle/build.boot
+++ b/bootstrap-toggle/build.boot
@@ -6,7 +6,7 @@
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
 (def +lib-version+ "2.2.2")
-(def +version+ (str +lib-version+ "-0"))
+(def +version+ (str +lib-version+ "-1"))
 
 (task-options!
  pom {:project     'cljsjs/bootstrap-toggle

--- a/bootstrap-toggle/resources/cljsjs/bootstrap-toggle/common/bootstrap-toggle.ext.js
+++ b/bootstrap-toggle/resources/cljsjs/bootstrap-toggle/common/bootstrap-toggle.ext.js
@@ -1,13 +1,5 @@
-var Toggle = function () {};
-Toggle.prototype.defaults = function () {};
-Toggle.prototype.render = function () {};
-Toggle.prototype.toggle = function () {};
-Toggle.prototype.on = function () {};
-Toggle.prototype.off = function () {};
-Toggle.prototype.enable = function () {};
-Toggle.prototype.disable = function () {};
-Toggle.prototype.update = function () {};
-Toggle.prototype.trigger = function () {};
-Toggle.prototype.destroy = function () {};
+/**
+ * @return {jQuery}
+ */
+jQuery.prototype.bootstrapToggle = function() {};
 
-var Plugin = function () {};


### PR DESCRIPTION
**Extern:** I updated the extern by hand.

The extern file was incorrect, as it was listing internal functions rather than the single publicly-visible function that the library intends you to use.