### PR TITLE
[material-ui] Fix missing extern for autocomplete filter options

### DIFF
--- a/material-ui/build.boot
+++ b/material-ui/build.boot
@@ -9,7 +9,7 @@
          '[boot.util :refer [sh]])
 
 (def +lib-version+ "0.16.0")
-(def +version+ (str +lib-version+ "-0"))
+(def +version+ (str +lib-version+ "-1"))
 (def +lib-folder+ (format "material-ui-%s" +lib-version+))
 
 (task-options!

--- a/material-ui/resources/cljsjs/material-ui/common/material-ui.ext.js
+++ b/material-ui/resources/cljsjs/material-ui/common/material-ui.ext.js
@@ -1,18 +1,24 @@
 var MaterialUI = {
-
-}
+    AutoComplete : {
+        noFilter: {},
+        defaultFilter: {},
+        caseInsensitiveFilter: {},
+        levenshteinDistanceFilter: {},
+        fuzzyFilter: {}
+    }
+};
 
 var MaterialUIStyles = {
     MuiThemeProvider : function() {},
     getMuiTheme : function() {},
     themeManager: {
-          getMuiTheme: function() {},
-          modifyRawThemeFontFamily: function() {},
-          modifyRawThemePalette: function() {},
-          modifyRawThemeSpacing: function() {}
+        getMuiTheme: function() {},
+        modifyRawThemeFontFamily: function() {},
+        modifyRawThemePalette: function() {},
+        modifyRawThemeSpacing: function() {}
     },
     transitions : {
         create : function() {},
         easeOut  : function() {}
     }
-}
+};


### PR DESCRIPTION
Update:

**Extern:** I updated the extern by hand.

Using filter options for the autocomplete field caused render errors with enabled advanced compilation.