### PR TITLE
[quill] Externs were not correct for Quill themes

### DIFF
--- a/quill/README.md
+++ b/quill/README.md
@@ -2,7 +2,7 @@
 
 [](dependency)
 ```clojure
-[cljsjs/quill "1.1.0-1"] ;; latest release
+[cljsjs/quill "1.1.0-2"] ;; latest release
 ```
 [](/dependency)
 

--- a/quill/build.boot
+++ b/quill/build.boot
@@ -5,7 +5,7 @@
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
 (def +lib-version+ "1.1.0")
-(def +version+ (str +lib-version+ "-1"))
+(def +version+ (str +lib-version+ "-2"))
 
 (task-options!
   pom {:project     'cljsjs/quill

--- a/quill/resources/cljsjs/quill/common/quill.ext.js
+++ b/quill/resources/cljsjs/quill/common/quill.ext.js
@@ -736,50 +736,8 @@ var Quill = {
         }
       }
     },
-    "themes/bubble": {
-      "DEFAULTS": {
-        "modules": {
-          "toolbar": {
-            "handlers": {
-              "formula": function () {},
-              "image": function () {},
-              "video": function () {},
-              "link": function () {}
-            }
-          }
-        }
-      },
-      "themes": {
-        "default": {
-          "DEFAULTS": {
-            "modules": {}
-          },
-          "themes": {}
-        }
-      }
-    },
-    "themes/snow": {
-      "DEFAULTS": {
-        "modules": {
-          "toolbar": {
-            "handlers": {
-              "formula": function () {},
-              "image": function () {},
-              "video": function () {},
-              "link": function () {}
-            }
-          }
-        }
-      },
-      "themes": {
-        "default": {
-          "DEFAULTS": {
-            "modules": {}
-          },
-          "themes": {}
-        }
-      }
-    },
+    "themes/bubble": function() {},
+    "themes/snow": function() {},
     "ui/icons": {
       "align": {
         "": {},


### PR DESCRIPTION
This fixes a problem where Quill would complain about its themes not being registered

**Extern:** I updated the extern by hand.
