### PR TITLE
[clipboard] Patch-version update to v1.5.13

### DIFF
--- a/clipboard/build.boot
+++ b/clipboard/build.boot
@@ -5,7 +5,7 @@
 (require '[cljsjs.boot-cljsjs.packaging :refer :all]
          '[boot.core :as boot])
 
-(def +lib-version+ "1.5.9")
+(def +lib-version+ "1.5.13")
 (def +version+ (str +lib-version+ "-0"))
 
 (task-options!
@@ -19,7 +19,7 @@
 (deftask package []
   (comp
    (download :url (str "https://github.com/zenorocha/clipboard.js/archive/v" +lib-version+ ".zip")
-             :checksum "055d55bdd8d293e941a66fa849cdeae0"
+             :checksum "57a39e7eebafa5990413cb02799cd03c"
              :unzip true)
    (sift :move {#"^clipboard.js-[^/]+/dist/clipboard.js" "cljsjs/clipboard/development/clipboard.inc.js"})
    (sift :move {#"^clipboard.js-[^/]+/dist/clipboard.min.js" "cljsjs/clipboard/development/clipboard.min.js"})


### PR DESCRIPTION
Simple update from v1.5.9 to v1.5.13, which picks up some bugfixes, including a fix to a regression introduced in 1.5.9 (said fix landed in https://github.com/zenorocha/clipboard.js/releases/tag/v1.5.11)

Update:

**Extern:** The API did not change.

