### PR TITLE
[material-ui] Excluded react from material-ui-svg-icons

### DIFF
--- a/material-ui/README.md
+++ b/material-ui/README.md
@@ -4,7 +4,7 @@ http://www.material-ui.com/#/
 
 [](dependency)
 ```clojure
-[cljsjs/material-ui "0.16.0-2"] ;; latest release
+[cljsjs/material-ui "0.16.0-3"] ;; latest release
 ```
 [](/dependency)
 

--- a/material-ui/build.boot
+++ b/material-ui/build.boot
@@ -9,7 +9,7 @@
          '[boot.util :refer [sh]])
 
 (def +lib-version+ "0.16.0")
-(def +version+ (str +lib-version+ "-2"))
+(def +version+ (str +lib-version+ "-3"))
 (def +lib-folder+ (format "material-ui-%s" +lib-version+))
 
 (task-options!

--- a/material-ui/resources/webpack.config.js
+++ b/material-ui/resources/webpack.config.js
@@ -6,12 +6,16 @@ var entryName = "material-ui";
 var output = {
   filename: '[name].inc.js'
 };
+var externals = {};
 
 if (svgIcons) {
     output['libraryTarget'] = 'var';
     output['library'] = 'MaterialUISvgIcons';
     entryPath =  "./build/svg-icons/index.js";
     entryName = "material-ui-svg-icons";
+    externals = {
+        "react": "React"
+    };
 }
 
 var entry = {};
@@ -23,6 +27,7 @@ entry[entryName] = entryPath;
 module.exports = {
   entry : entry,
   output: output,
+  externals: externals,
   plugins: [
     new webpack.DefinePlugin({
       'process.env': {


### PR DESCRIPTION
As @Deraen notified me about `material-ui-svg-icon` including React, I fixed it, but it decreased file size just slightly (roughly -100KB dev, -10KB minified).
Svg icons file is relatively big, simply because there's just many icons.  

Thanks a lot for a tip!

**Extern:** The API did not change.
