### PR TITLE
[moment.js] Upgrade 2.10.6 -> 2.15.2

### DIFF
--- a/moment/build.boot
+++ b/moment/build.boot
@@ -4,8 +4,8 @@
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
-(def +lib-version+ "2.10.6")
-(def +version+ (str +lib-version+ "-4"))
+(def +lib-version+ "2.15.2")
+(def +version+ (str +lib-version+ "-1"))
 
 (task-options!
   push {:ensure-clean false}
@@ -42,7 +42,7 @@
 (deftask package []
   (comp
     (download :url (format "https://github.com/moment/moment/archive/%s.zip" +lib-version+)
-              :checksum "104b02737546e79505172590f4ebc523"
+              :checksum "4b18e1bcccc45762ce97f233b980c315"
               :unzip true)
     ; Locale files are not immediately named .inc.js as we don't want deps-cljs to find them
     (sift :move {#"^moment-[^\/]*/moment\.js"          "cljsjs/development/moment.inc.js"

--- a/moment/resources/cljsjs/common/moment.ext.js
+++ b/moment/resources/cljsjs/common/moment.ext.js
@@ -524,3 +524,9 @@ Moment.prototype.relativeTimeThreshold = function() {};
  * @since 2.9.0
  */
 Moment.prototype.utcOffset = function() {};
+
+
+/**
+ * @since 2.12.0
+ */
+Moment.prototype.locales = function() {};


### PR DESCRIPTION
I did not see any big api changes, only one new method was added. I tested similar upgrade recently on my own projects, but I use small subset of moment, so can't say for sure if api changed.