### PR TITLE
[react] Add missing externs

### DIFF
--- a/react/README.md
+++ b/react/README.md
@@ -1,7 +1,7 @@
 # cljsjs/react
 
 ```clojure
-[cljsjs/react "15.3.1-0"] ;; latest release
+[cljsjs/react "15.3.1-1"] ;; latest release
 ```
 
 This jar comes with `deps.cljs` as used by the [Foreign Libs][flibs] feature

--- a/react/build.boot
+++ b/react/build.boot
@@ -5,7 +5,7 @@
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
 (def +lib-version+ "15.3.1")
-(def +version+ (str +lib-version+ "-0"))
+(def +version+ (str +lib-version+ "-1"))
 (def +checksum+ "609BE41974089150F840D84DC677CAA3")
 
 (task-options!

--- a/react/resources/cljsjs/react/common/react.ext.js
+++ b/react/resources/cljsjs/react/common/react.ext.js
@@ -935,6 +935,14 @@ React.DOM.iframe = function(props, children) {};
  * @return {React.Component}
  * @protected
  */
+React.DOM.image = function(props, children) {};
+
+/**
+ * @param {Object=} props
+ * @param {...React.ChildrenArgument} children
+ * @return {React.Component}
+ * @protected
+ */
 React.DOM.img = function(props, children) {};
 
 /**

--- a/react/resources/cljsjs/react/common/react.ext.js
+++ b/react/resources/cljsjs/react/common/react.ext.js
@@ -647,6 +647,14 @@ React.DOM.cite = function(props, children) {};
  * @return {React.Component}
  * @protected
  */
+React.DOM.clipPath = function(props, children) {};
+
+/**
+ * @param {Object=} props
+ * @param {...React.ChildrenArgument} children
+ * @return {React.Component}
+ * @protected
+ */
 React.DOM.code = function(props, children) {};
 
 /**
@@ -720,6 +728,14 @@ React.DOM.details = function(props, children) {};
  * @protected
  */
 React.DOM.dfn = function(props, children) {};
+
+/**
+ * @param {Object=} props
+ * @param {...React.ChildrenArgument} children
+ * @return {React.Component}
+ * @protected
+ */
+React.DOM.dialog = function(props, children) {};
 
 /**
  * @param {Object=} props
@@ -1159,6 +1175,14 @@ React.DOM.pattern = function(props, children) {};
  * @return {React.Component}
  * @protected
  */
+React.DOM.picture = function(props, children) {};
+
+/**
+ * @param {Object=} props
+ * @param {...React.ChildrenArgument} children
+ * @return {React.Component}
+ * @protected
+ */
 React.DOM.polygon = function(props, children) {};
 
 /**
@@ -1328,6 +1352,22 @@ React.DOM.style = function(props, children) {};
  * @protected
  */
 React.DOM.sub = function(props, children) {};
+
+/**
+ * @param {Object=} props
+ * @param {...React.ChildrenArgument} children
+ * @return {React.Component}
+ * @protected
+ */
+React.DOM.summary = function(props, children) {};
+
+/**
+ * @param {Object=} props
+ * @param {...React.ChildrenArgument} children
+ * @return {React.Component}
+ * @protected
+ */
+React.DOM.sup = function(props, children) {};
 
 /**
  * @param {Object=} props


### PR DESCRIPTION
Update:

**Extern:** I updated the extern by hand.

React.DOM had the following missing externs: clipPath, dialog, picture,
summary, sup.