### PR TITLE
Fix exports for libtess (node.js compat)

### DIFF
--- a/libtess/build.boot
+++ b/libtess/build.boot
@@ -5,7 +5,7 @@
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
 (def +lib-version+ "1.2.2")
-(def +version+ (str +lib-version+ "-0"))
+(def +version+ (str +lib-version+ "-1"))
 
 (task-options!
  pom {:project 'cljsjs/libtess
@@ -19,7 +19,7 @@
   "https://raw.githubusercontent.com/")
 
 (def export
-  "(window||global)")
+  "(((typeof window != 'undefined') && window) || global)")
 
 (deftask package []
   (comp

--- a/libtess/build.boot
+++ b/libtess/build.boot
@@ -4,6 +4,10 @@
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
+;; WARNING - when updating libtess version here, make sure the replace-content
+;; in the package task still works as expected, ie. removes CommonJS exports,
+;; and exports to either window (browser, browserify) or global (node.js)
+
 (def +lib-version+ "1.2.2")
 (def +version+ (str +lib-version+ "-1"))
 


### PR DESCRIPTION
This fix makes it work when compiling to `nodejs` target.