### PR TITLE
[d3-tip] Actually depend on d3

### DIFF
--- a/d3-tip/build.boot
+++ b/d3-tip/build.boot
@@ -1,12 +1,12 @@
 (set-env!
  :resource-paths #{"resources"}
- :dependencies '[[cljsjs/d3 "3.5.16-0" :scope "test"]
+ :dependencies '[[cljsjs/d3 "3.5.16-0"]
                  [cljsjs/boot-cljsjs "0.5.2" :scope "test"]])
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
 (def +lib-version+ "0.6.7")
-(def +version+ (str +lib-version+ "-0"))
+(def +version+ (str +lib-version+ "-1"))
 
 (task-options!
  pom  {:project     'cljsjs/d3-tip


### PR DESCRIPTION
d3 should not be a `:test` dependency for d3-tip.