### PR TITLE
Add documentation about using react-flexbox-grid.

### DIFF
--- a/react-flexbox-grid/README.md
+++ b/react-flexbox-grid/README.md
@@ -15,4 +15,26 @@ you can require the packaged library like so:
   (:require cljsjs.react-flexbox-grid))
 ```
 
+You also need to include the CSS. If you are using [sass4clj](https://github.com/Deraen/sass4clj) it'll look like this:
+
+```scss
+@import "cljsjs/react-flexbox-grid/development/react-flexbox-grid.inc";
+```
+
+for the development version of the CSS or
+
+```scss
+@import "cljsjs/react-flexbox-grid/production/react-flexbox-grid.min.inc";
+```
+
+for the production minified version.
+
+You can use it like this:
+
+```clojure
+[:> (.-Grid js/ReactFlexboxGrid)
+ [:> (.-Row js/ReactFlexboxGrid)
+  [:> (.-Col js/ReactFlexboxGrid) {:xs 6 :md 3} "Hello World!"]]]
+```
+
 [flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies


### PR DESCRIPTION
Keep relevant lines. You should select one choice for each category
(e.g. **Extern**), if none of choices is valid you should probably do
something or at least add a comment here.

Update:

**Extern:** The API did not change.