### PR TITLE
js-beautify for html code

### DIFF
--- a/js-beautify/README.md
+++ b/js-beautify/README.md
@@ -2,7 +2,7 @@
 
 [](dependency)
 ```clojure
-[cljsjs/js-beautify "1.6.2-0"] ;; latest release
+[cljsjs/js-beautify "1.6.8-0"] ;; latest release
 ```
 [](/dependency)
 
@@ -15,6 +15,20 @@ you can require and use the packaged library like so:
   (:require cljsjs.js-beautify))
 
 (def asset-loader js/js_beautify)
+```
+
+```clojure
+(ns application.core
+  (:require cljsjs.js-beautify.html))
+
+(def asset-loader js/html_beautify)
+```
+
+```clojure
+(ns application.core
+  (:require cljsjs.js-beautify.css))
+
+(def asset-loader js/css_beautify)
 ```
 
 [flibs]: https://github.com/clojure/clojurescript/wiki/Foreign-Dependencies

--- a/js-beautify/build.boot
+++ b/js-beautify/build.boot
@@ -4,7 +4,7 @@
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
-(def +lib-version+ "1.6.2")
+(def +lib-version+ "1.6.8")
 (def +version+ (str +lib-version+ "-0"))
 
 (task-options!
@@ -17,13 +17,21 @@
 
 (deftask package []
   (comp
-    (download :url (format "https://github.com/beautify-web/js-beautify/archive/v%s.zip" +lib-version+)
-              :checksum "d5baf366068832ceee28ef3e6ae9d523"
-              :unzip true)
-    (sift :move {#"^js-beautify-([\d\.]+)/js/lib/beautify\.js$" "cljsjs/js-beautify/development/beautify.inc.js"})
-    (minify :in "cljsjs/js-beautify/development/beautify.inc.js"
-            :out "cljsjs/js-beautify/production/beautify.min.inc.js")
-    (sift :include #{#"^cljsjs"})
-    (deps-cljs :name "cljsjs.js-beautify")
-    (pom)
-    (jar)))
+   (download :url (format "https://github.com/beautify-web/js-beautify/archive/v%s.zip" +lib-version+)
+             :checksum "b0b6d79bbd801b2742a26e2e35b4138a"
+             :unzip true)
+   (sift :move {#"^js-beautify-([\d\.]+)/js/lib/beautify\.js$" "cljsjs/js-beautify/development/beautify.inc.js"
+                #"^js-beautify-([\d\.]+)/js/lib/beautify-html\.js$" "cljsjs/js-beautify/development/beautify-html.inc.js"
+                #"^js-beautify-([\d\.]+)/js/lib/beautify-css\.js$" "cljsjs/js-beautify/development/beautify-css.inc.js"})
+   (minify :in "cljsjs/js-beautify/development/beautify.inc.js"
+           :out "cljsjs/js-beautify/production/beautify.min.inc.js"
+           :lang :ecmascript5)
+   (minify :in "cljsjs/js-beautify/development/beautify-html.inc.js"
+           :out "cljsjs/js-beautify/production/beautify-html.min.inc.js"
+           :lang :ecmascript5)
+   (minify :in "cljsjs/js-beautify/development/beautify-css.inc.js"
+           :out "cljsjs/js-beautify/production/beautify-css.min.inc.js"
+           :lang :ecmascript5)
+   (sift :include #{#"^cljsjs" #"^deps.cljs"})
+   (pom)
+   (jar)))

--- a/js-beautify/resources/cljsjs/js-beautify/common/js-beautify.ext.js
+++ b/js-beautify/resources/cljsjs/js-beautify/common/js-beautify.ext.js
@@ -1,1 +1,3 @@
-function js_beautify() {}
+var js_beautify = function () {};
+var html_beautify = function () {};
+var css_beautify = function () {};

--- a/js-beautify/resources/deps.cljs
+++ b/js-beautify/resources/deps.cljs
@@ -1,0 +1,4 @@
+{:foreign-libs [{:provides ["cljsjs.js-beautify"] :file "cljsjs/js-beautify/development/beautify.inc.js" :file-min "cljsjs/js-beautify/production/beautify.min.inc.js"}
+                {:provides ["cljsjs.js-beautify.html"] :file "cljsjs/js-beautify/development/beautify-html.inc.js" :file-min "cljsjs/js-beautify/production/beautify-html.min.inc.js"}
+                {:provides ["cljsjs.js-beautify.css"] :file "cljsjs/js-beautify/development/beautify-css.inc.js" :file-min "cljsjs/js-beautify/production/beautify-css.min.inc.js"}]
+ :externs ["cljsjs/js-beautify/common/js-beautify.ext.js"]}

--- a/react-dates/README.md
+++ b/react-dates/README.md
@@ -2,7 +2,7 @@
 
 [](dependency)
 ```clojure
-[cljsjs/react-dates "3.4.0-0"] ;; latest release
+[cljsjs/react-dates "3.4.0-1"] ;; latest release
 ```
 [](/dependency)
 

--- a/zxcvbn/README.md
+++ b/zxcvbn/README.md
@@ -2,7 +2,7 @@
 
 [](dependency)
 ```clojure
-[cljsjs/zxcvbn "4.4.0-0"] ;; latest release
+[cljsjs/zxcvbn "4.4.0-1"] ;; latest release
 ```
 [](/dependency)
 


### PR DESCRIPTION
This is probably not the ideal solution for a library with multiple js files. The problem is that in current js-beautify there's only beautification for js code while the library offers a beautification for .css and .html in these seperate .js files.

Using :ecmascript5 for minification was important to loose of errors complaining about commas and IE8.

This 1 extern was tested with advanced compilation.


New package:
**Extern:** Written by hand.


