### PR TITLE
[semantic-ui-react] Initial commit v0.64.0

### DIFF
--- a/semantic-ui-react/README.md
+++ b/semantic-ui-react/README.md
@@ -17,4 +17,30 @@ you can require the packaged library like so:
   (:require cljsjs.semantic-ui-react))
 ```
 
+Currently the only extern declared is `semanticUIReact`. All
+components are available via properties of `js/semanticUIReact` and
+can be accessed via `goog.object/get` and
+`goog.object/getValueByKeys`.
+
+Example:
+
+```clojure
+(ns application.core
+  (:require cljsjs.semantic-ui-react
+            goog.object
+            [reagent.core :as r))
+
+(def semantic-ui js/semanticUIReact)
+
+;; Top-level component:
+(def button (goog.object/get semantic-ui "Button"))
+
+;; Nested component:
+(def menu-item (goog.object/getValuebykeys semantic-ui "Menu" "Item"))
+
+;; Reagent usage:
+(defn view []
+  [:> button {:onClick #(println "Hello world")} "Press Me"])
+```
+
 [flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies

--- a/semantic-ui-react/README.md
+++ b/semantic-ui-react/README.md
@@ -1,0 +1,20 @@
+# cljsjs/semantic-ui-react
+
+http://react.semantic-ui.com
+
+[](dependency)
+```clojure
+[cljsjs/semantic-ui-react "0.64.0-0"] ;; latest release
+```
+[](/dependency)
+
+This jar comes with `deps.cljs` as used by the [Foreign Libs][flibs] feature
+of the Clojurescript compiler. After adding the above dependency to your project
+you can require the packaged library like so:
+
+```clojure
+(ns application.core
+  (:require cljsjs.semantic-ui-react))
+```
+
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies

--- a/semantic-ui-react/build.boot
+++ b/semantic-ui-react/build.boot
@@ -1,0 +1,36 @@
+(set-env!
+  :resource-paths #{"resources"}
+  :dependencies '[[cljsjs/boot-cljsjs "0.5.2" :scope "test"]])
+
+(require '[cljsjs.boot-cljsjs.packaging :refer :all]
+         '[boot.core :as boot]
+         '[boot.tmpdir :as tmpd]
+         '[clojure.java.io :as io]
+         '[boot.util :refer [sh]])
+
+(def +lib-version+ "0.64.0")
+(def +version+ (str +lib-version+ "-0"))
+(def +lib-folder+ (format "semantic-ui-react-%s" +lib-version+))
+
+(task-options!
+  pom {:project     'cljsjs/semantic-ui-react
+       :version     +version+
+       :description "React components for Semantic UI"
+       :url         "http://react.semantic-ui.com/"
+       :scm         {:url "https://github.com/cljsjs/packages"}
+       :license     {"BSD" "http://opensource.org/licenses/BSD-3-Clause"}})
+
+(def url (format "https://unpkg.com/semantic-ui-react@%s/dist/umd/semantic-ui-react.min.js" +lib-version+))
+
+(deftask download-semantic-ui-react []
+  (download :url      url
+            :checksum "E42CA19D2BD0928A94C1C9CD56FE573A"))
+
+(deftask package []
+  (comp
+    (download-semantic-ui-react)
+    (sift :move {#"semantic-ui-react.min.js"
+                 "cljsjs/semantic-ui-react/common/semantic-ui-react.inc.js"})
+    (deps-cljs :name "cljsjs.semantic-ui-react")
+    (pom)
+    (jar)))

--- a/semantic-ui-react/resources/cljsjs/semantic-ui-react/common/semantic-ui-react.ext.js
+++ b/semantic-ui-react/resources/cljsjs/semantic-ui-react/common/semantic-ui-react.ext.js
@@ -1,0 +1,3 @@
+var TopLevel = {
+"semanticUIReact" : function () {}
+}


### PR DESCRIPTION
Only one extern var is set `semanticUIReact` since all react elements can be safely retrieved via `aget` from that class.

New package:

**Extern:** Written by hand.
