### PR TITLE
[react-mdl] Add cljsjs.react.dom dependency

### DIFF
--- a/react-mdl/build.boot
+++ b/react-mdl/build.boot
@@ -10,7 +10,7 @@
          '[boot.task-helpers :as helpers])
 
 (def +lib-version+ "1.5.4")
-(def +version+ (str +lib-version+ "-0"))
+(def +version+ (str +lib-version+ "-1"))
 
 (task-options!
  pom  {:project     'cljsjs/react-mdl

--- a/react-mdl/resources/deps.cljs
+++ b/react-mdl/resources/deps.cljs
@@ -2,7 +2,7 @@
         [{:file "cljsjs/react-mdl/development/ReactMDL.inc.js"
           :file-min "cljsjs/react-mdl/production/ReactMDL.min.inc.js"
           :provides ["cljsjs.react-mdl"]
-          :requires ["cljsjs.react" "cljsjs.react-mdl-extra"]}
+          :requires ["cljsjs.react" "cljsjs.react.dom" "cljsjs.react-mdl-extra"]}
         {:file "cljsjs/react-mdl/development/material.inc.js"
          :file-min "cjsjs/react-mdl/production/material.min.inc.js"
          :provides ["cljsjs.react-mdl-extra"]}]


### PR DESCRIPTION
I was getting an error when using the react-mdl package, `Cannot read property 'findDOMNode' of undefined`. I found it was due a missing dependency on `cljsjs.react.dom`, all this PR does is add that dependency.

**Extern:** The API did not change.