### PR TITLE
[leaflet] Fix severe dupe key errors revealed by cljs compiler v1.9.456

### DIFF
--- a/leaflet/README.md
+++ b/leaflet/README.md
@@ -2,7 +2,7 @@
 
 [](dependency)
 ```clojure
-[cljsjs/leaflet "0.7.7-7"] ;; latest release
+[cljsjs/leaflet "0.7.7-8"] ;; latest release
 ```
 [](/dependency)
 

--- a/leaflet/build.boot
+++ b/leaflet/build.boot
@@ -5,7 +5,7 @@
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
 (def +lib-version+ "0.7.7")
-(def +version+ (str +lib-version+ "-7"))
+(def +version+ (str +lib-version+ "-8"))
 
 (task-options!
  pom  {:project     'cljsjs/leaflet

--- a/leaflet/resources/cljsjs/common/leaflet.ext.js
+++ b/leaflet/resources/cljsjs/common/leaflet.ext.js
@@ -737,7 +737,6 @@ var L = {
     "getLayers": function () {},
     "eachLayer": function () {},
     "clearLayers": function () {},
-    "hasLayer": function () {},
     "toGeoJSON": function () {},
    },
   "FeatureGroup": function () {},
@@ -760,7 +759,6 @@ var L = {
   "polyline": {
     "addTo": function () {},       
     "bindPopup": function () {},   
-    "bindPopup": function () {},   
     "unbindPopup": function () {}, 
     "openPopup": function () {},   
     "closePopup": function () {},  
@@ -773,7 +771,6 @@ var L = {
     "setLatLngs": function () {}, 
     "getLatLngs": function () {}, 
     "spliceLatLngs": function () {},
-    "getBounds": function () {}, 
     "toGeoJSON": function () {} 
   },
   "PolyUtil": {
@@ -783,7 +780,6 @@ var L = {
   "polygon": {
     "addTo": function () {},       
     "bindPopup": function () {},   
-    "bindPopup": function () {},   
     "unbindPopup": function () {}, 
     "openPopup": function () {},   
     "closePopup": function () {},  
@@ -796,7 +792,6 @@ var L = {
     "setLatLngs": function () {}, 
     "getLatLngs": function () {}, 
     "spliceLatLngs": function () {},
-    "getBounds": function () {}, 
     "toGeoJSON": function () {}
   },
   "MultiPolyline": function () {},


### PR DESCRIPTION
Update:

**Leaflet**: I updated the extern by hand.

Leaflet package fails to compile with latest release of the ClojureScript compiler. The package build fails with the following strict warning:

`ERROR - Object literal contains illegal duplicate key "getBounds", disallowed in ES5 strict mode`.

This patch fixes 5 of these errors.


