### PR TITLE
[react-leaflet] Update leaflet dependency to latest version; Bump rea…

### DIFF
--- a/react-leaflet/README.md
+++ b/react-leaflet/README.md
@@ -2,7 +2,7 @@
 
 [](dependency)
 ```clojure
-[cljsjs/react-leaflet "0.12.3-3"] ;; latest release
+[cljsjs/react-leaflet "0.12.3-4"] ;; latest release
 ```
 [](/dependency)
 

--- a/react-leaflet/build.boot
+++ b/react-leaflet/build.boot
@@ -1,12 +1,12 @@
 (set-env!
   :resource-paths #{"resources"}
   :dependencies '[[cljsjs/boot-cljsjs "0.5.2" :scope "test"]
-                  [cljsjs/leaflet "0.7.7-7"]])
+                  [cljsjs/leaflet "0.7.7-8"]])
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
 (def +lib-version+ "0.12.3")
-(def +version+ (str +lib-version+ "-3"))
+(def +version+ (str +lib-version+ "-4"))
 
 (task-options!
  pom  {:project     'cljsjs/react-leaflet


### PR DESCRIPTION
Update:

**React-leaflet**: The API did not change.

Update Leaflet dependency to latest released version; Bump React-leaflet version.

This relates to the recent merged *Leaflet* PR here: https://github.com/cljsjs/packages/pull/967