### PR TITLE
Update material components to 0.3.0

### DIFF
--- a/material-components/build.boot
+++ b/material-components/build.boot
@@ -8,7 +8,7 @@
          '[clojure.java.io :as io]
          '[boot.util :refer [sh]])
 
-(def +lib-version+ "0.1.1")
+(def +lib-version+ "0.3.0")
 (def +version+ (str +lib-version+ "-0"))
 
 (task-options!
@@ -28,7 +28,7 @@
               :let [target (io/file tmp (tmpd/path f))]]
         (io/make-parents target)
         (io/copy (tmpd/file f) target))
-      (binding [boot.util/*sh-dir* (str (io/file tmp (format "material-components-web-%s" +lib-version+)))]
+      (binding [boot.util/*sh-dir* (str (io/file tmp (format "material-components-web-material-components-web-%s" +lib-version+)))]
         ((sh "npm" "install"))
         ((sh "npm" "run" "dist")))
       (-> fileset (boot/add-resource tmp) boot/commit!))))
@@ -36,16 +36,18 @@
 (deftask package []
   (task-options! push {:ensure-branch nil})
   (comp
-   (download :url (str "https://github.com/material-components/material-components-web/archive/v" +lib-version+ ".zip")
-             :checksum "758a02ddaf204ec4247d3b8298f2b7be"
+   (download :url (str "https://github.com/material-components/material-components-web/archive/material-components-web@" +lib-version+ ".zip")
+             :checksum "b3dbee1a4ac41751af22538bc48a2de3"
              :unzip true)
+
+
 
    (build-material-components)
 
-   (sift :move {(re-pattern (str "^material-components-web-" +lib-version+ "/build/material-components-web.js$")) "cljsjs/material-components/development/material-components.inc.js"})
-   (sift :move {(re-pattern (str "^material-components-web-" +lib-version+ "/build/material-components-web.css$")) "cljsjs/material-components/development/material-components.inc.css"})
-   (sift :move {(re-pattern (str "^material-components-web-" +lib-version+ "/build/material-components-web.min.js$")) "cljsjs/material-components/production/material-components.min.inc.js"})
-   (sift :move {(re-pattern (str "^material-components-web-" +lib-version+ "/build/material-components-web.min.css$")) "cljsjs/material-components/production/material-components.min.inc.css"})
+   (sift :move {(re-pattern (str "^material-components-web-material-components-web-" +lib-version+ "/build/material-components-web.js$")) "cljsjs/material-components/development/material-components.inc.js"})
+   (sift :move {(re-pattern (str "^material-components-web-material-components-web-" +lib-version+ "/build/material-components-web.css$")) "cljsjs/material-components/development/material-components.inc.css"})
+   (sift :move {(re-pattern (str "^material-components-web-material-components-web-" +lib-version+ "/build/material-components-web.min.js$")) "cljsjs/material-components/production/material-components.min.inc.js"})
+   (sift :move {(re-pattern (str "^material-components-web-material-components-web-" +lib-version+ "/build/material-components-web.min.css$")) "cljsjs/material-components/production/material-components.min.inc.css"})
 
    (sift :include #{#"^cljsjs"})
    (deps-cljs :name "cljsjs.material-components")


### PR DESCRIPTION
Keep relevant lines. You should select one choice for each category
(e.g. **Extern**), if none of choices is valid you should probably do
something or at least add a comment here.
Update:

**Extern:** The API did not change.
