### PR TITLE
[aws-sdk-js]: fix duplicate keys in aws-sdk-js externs causing `:optimizations "advanced"` to fail on clojurescript 1.9.456

### DIFF
--- a/aws-sdk-js/build.boot
+++ b/aws-sdk-js/build.boot
@@ -5,7 +5,7 @@
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
 (def +lib-version+ "2.2.41")
-(def +version+ (str +lib-version+ "-3"))
+(def +version+ (str +lib-version+ "-4"))
 
 (task-options!
   pom  {:project     'cljsjs/aws-sdk-js

--- a/aws-sdk-js/resources/cljsjs/aws-sdk-js/common/aws-sdk-js.ext.js
+++ b/aws-sdk-js/resources/cljsjs/aws-sdk-js/common/aws-sdk-js.ext.js
@@ -37039,7 +37039,6 @@ AWS.S3.prototype = {
   "abortMultipartUpload": function() {},
   "completeMultipartUpload": function() {},
   "copyObject": function() {},
-  "createBucket": function() {},
   "createMultipartUpload": function() {},
   "deleteBucket": function() {},
   "deleteBucketCors": function() {},
@@ -37068,7 +37067,6 @@ AWS.S3.prototype = {
   "getObject": function() {},
   "getObjectAcl": function() {},
   "getObjectTorrent": function() {},
-  "getSignedUrl": function() {},
   "headBucket": function() {},
   "headObject": function() {},
   "listBuckets": function() {},
@@ -37094,10 +37092,8 @@ AWS.S3.prototype = {
   "putObject": function() {},
   "putObjectAcl": function() {},
   "restoreObject": function() {},
-  "upload": function() {},
   "uploadPart": function() {},
-  "uploadPartCopy": function() {},
-  "waitFor": function() {}
+  "uploadPartCopy": function() {}
 };
 AWS.S3.__super__.prototype = {
   "constructor": function () {},


### PR DESCRIPTION
The current AWS SDK build had 4 duplicate keys in the externs: `createBucket`, `getSignedUrl`, `upload` & `waitFor`. Duplicate keys aren't allowed in ES5 strict mode so as of clojurescript `1.9.456` this cljsjs package does **not** compile with `:optimizations "advanced"`.

See screenshot:

![screenshot](https://puu.sh/tNfAY/1ca24a6878.png)

This PR removes removes the 4 duplicate keys.
