### PR TITLE
Point to the wrapper that makes it easy to use react-toolbox in Reagent.

### DIFF
--- a/react-toolbox/README.md
+++ b/react-toolbox/README.md
@@ -28,3 +28,6 @@ you can require the packaged library like:
 ```
 
 [flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies
+
+If you are using Reagent, a wrapper for this cljsjs library is being developed that will provide ready to use well
+documented Reagent components: [Reagent Toolbox](https://github.com/dashmantech/reagent-toolbox).


### PR DESCRIPTION
Documentation change.