### PR TITLE
[material-ui-chip-input] Update to version 0.12.2

### DIFF
--- a/material-ui-chip-input/README.md
+++ b/material-ui-chip-input/README.md
@@ -2,7 +2,7 @@
 
 [](dependency)
 ```clojure
-[cljsjs/material-ui-chip-input "0.12.0-0"] ;; latest release
+[cljsjs/material-ui-chip-input "0.12.2-0"] ;; latest release
 ```
 [](/dependency)
 

--- a/material-ui-chip-input/build.boot
+++ b/material-ui-chip-input/build.boot
@@ -2,7 +2,7 @@
   :resource-paths #{"resources"}
   :dependencies '[[cljsjs/boot-cljsjs "0.5.2"  :scope "test"]])
 
-(def +lib-version+ "0.12.0")
+(def +lib-version+ "0.12.2")
 (def +version+ (str +lib-version+ "-0"))
 (def +lib-folder+ (format "material-ui-chip-input-%s" +lib-version+))
 
@@ -24,7 +24,7 @@
 
 (deftask download-material-ui-chip-input []
          (download :url url
-                   :checksum "891cd0405857400e5b2389ce4e094a80"
+                   :checksum "5dafd3bbc1c343b8df212ccf2f5f69d2"
                    :unzip true))
 
 (def webpack-file-name "webpack.config.js")

--- a/material-ui-chip-input/resources/webpack.config.js
+++ b/material-ui-chip-input/resources/webpack.config.js
@@ -22,7 +22,7 @@ module.exports = {
       {
         test: /\.jsx?$/,
         exclude: /(node_modules|bower_components)/,
-        loader: 'babel',
+        loader: 'babel-loader',
         query: {
           presets: ['es2015', 'react', 'stage-0']
         }


### PR DESCRIPTION
Update:

**Extern:** The API did not change.

