### PR TITLE
[tether] Update to 1.4.0; add methods to externs

### DIFF
--- a/tether/README.md
+++ b/tether/README.md
@@ -2,7 +2,7 @@
 
 [](dependency)
 ```clojure
-[cljsjs/tether "1.1.1-0"] ;; latest release
+[cljsjs/tether "1.4.0-0"] ;; latest release
 ```
 [](/dependency)
 
@@ -13,6 +13,15 @@ you can require the packaged library like so:
 ```clojure
 (ns application.core
   (:require cljsjs.tether))
+```
+
+And then use it like so:
+
+```clojure
+(let [options {:element ..., :target ...}
+      tether (new js/Tether (clj->js options))]
+  ;do whatever to it
+  (.position tether))
 ```
 
 [flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies

--- a/tether/build.boot
+++ b/tether/build.boot
@@ -1,29 +1,24 @@
 (set-env!
   :resource-paths #{"resources"}
-  :dependencies '[[cljsjs/boot-cljsjs "0.5.2"  :scope "test"]])
+  :dependencies '[[cljsjs/boot-cljsjs "0.6.0"  :scope "test"]])
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
-(def +lib-version+ "1.1.1")
+(def +lib-version+ "1.4.0")
 (def +version+ (str +lib-version+ "-0"))
 
 (task-options!
  pom  {:project     'cljsjs/tether
        :version     +version+
        :description "A positioning engine to make overlays, tooltips and dropdowns better #hubspot-open-source"
-       :url         "http://github.hubspot.com/tether"
+       :url         "http://tether.io"
        :scm         {:url "https://github.com/cljsjs/packages"}
        :license     {"MIT" "http://opensource.org/licenses/MIT"}})
-
-(require '[boot.core :as c]
-         '[boot.tmpdir :as tmpd]
-         '[clojure.java.io :as io]
-         '[clojure.string :as string])
 
 (deftask package []
   (comp
     (download :url (str "https://github.com/HubSpot/tether/archive/v" +lib-version+ ".zip")
-	      :checksum "87C8DEC00FD6D9690449EA3A08DC1FA7"	
+              :checksum "A1A53FDD74FD4D8D1B41C10E85E9B456"
               :unzip true)
 
     (sift :move {#"^tether.*[/ \\]dist[/ \\]js[/ \\]tether.js$" "cljsjs/tether/development/tether.inc.js"

--- a/tether/resources/cljsjs/tether/common/tether.ext.js
+++ b/tether/resources/cljsjs/tether/common/tether.ext.js
@@ -1,29 +1,34 @@
-var Tether = {
-    "modules": {
-        "0": {
-            "position": function () {}
-        },
-        "1": {
-            "position": function () {}
-        },
-        "2": {
-            "position": function () {}
-        }
-    },
-    "Utils": {
-        "getScrollParent": function () {},
-        "getBounds": function () {},
-        "getOffsetParent": function () {},
-        "extend": function () {},
-        "addClass": function () {},
-        "removeClass": function () {},
-        "hasClass": function () {},
-        "updateClasses": function () {},
-        "defer": function () {},
-        "flush": function () {},
-        "uniqueId": function () {},
-        "Evented": function () {},
-        "getScrollBarSize": function () {}
-    },
-    "position": function () {}
-}
+/*
+Tether v1.4.0 (https://github.com/HubSpot/tether/)
+Hand-written externs, because the auto-generated ones omit many important methods
+*/
+
+var Tether = {};
+Tether.prototype = {
+  setOptions: function (opts) {},
+  position: function () {},
+  enable: function () {},
+  disable: function () {},
+  destroy: function () {}
+};
+
+Tether.Utils = {
+  addClass: function () {},
+  defer: function () {},
+  extend: function () {},
+  flush: function () {},
+  getBounds: function () {},
+  getOffsetParent: function () {},
+  getScrollBarSize: function () {},
+  getScrollParents: function () {},
+  hasClass: function () {},
+  removeClass: function () {},
+  uniqueId: function () {},
+  updateClasses: function () {},
+  Evented: {
+    off: function() {},
+    on: function() {},
+    once: function() {},
+    trigger: function() {},
+  }
+};


### PR DESCRIPTION
* Update Tether version to latest (1.4.0).
* Switch to handwritten externs because the automatically-generated
externs were missing a lot of methods and had some extra junk
* Add a small usage example to the README
* Tidy up `build.boot`, use latest `boot-cljsjs`
