### PR TITLE
Add react chartjs 2

### DIFF
--- a/reactstrap/build.boot
+++ b/reactstrap/build.boot
@@ -2,7 +2,7 @@
   :resource-paths #{"resources"}
   :dependencies '[[cljsjs/boot-cljsjs "0.5.2" :scope "test"]
                   [cljsjs/react-with-addons "15.4.2-2"]
-                  [cljsjs/react-dom "15.4.2-2"]])
+                  [cljsjs/react-dom "15.4.2-2" :exclusions [cljsjs/react]]])
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
@@ -27,6 +27,6 @@
            (download :url (download-url true) :name "reactstrap.min.js")
            (sift :move {#"reactstrap.js"     "cljsjs/reactstrap/development/reactstrap.inc.js"
                         #"reactstrap.min.js" "cljsjs/reactstrap/production/reactstrap.min.inc.js"})
-           (deps-cljs :name "cljsjs.reactstrap" :requires ["cljsjs.react" "cljsjs.react-dom"])
+           (deps-cljs :name "cljsjs.reactstrap" :requires ["cljsjs.react" "cljsjs.react.dom"])
            (pom)
            (jar)))

--- a/reactstrap/build.boot
+++ b/reactstrap/build.boot
@@ -7,7 +7,7 @@
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
 (def +lib-version+ "4.2.0")
-(def +version+ (str +lib-version+ "-0"))
+(def +version+ (str +lib-version+ "-1"))
 
 (task-options!
   pom {:project     'cljsjs/reactstrap


### PR DESCRIPTION
Fixed incorrect namespace for ReactDOM and exclude cljsjs/react from react-dom. See previous discussion https://github.com/cljsjs/packages/pull/1016. 