### PR TITLE
Update material design components to 0.6.0

### DIFF
--- a/material-components/build.boot
+++ b/material-components/build.boot
@@ -8,7 +8,7 @@
          '[clojure.java.io :as io]
          '[boot.util :refer [sh]])
 
-(def +lib-version+ "0.5.0")
+(def +lib-version+ "0.6.0")
 (def +version+ (str +lib-version+ "-0"))
 
 (task-options!
@@ -37,7 +37,7 @@
   (task-options! push {:ensure-branch nil})
   (comp
    (download :url (str "https://github.com/material-components/material-components-web/archive/v" +lib-version+ ".zip")
-             :checksum "c316910bc09ad8e35d5cd9af488b469a"
+             :checksum "bc9450d49e8243a8272d12c4d9746d2b"
              :unzip true)
 
    (build-material-components)


### PR DESCRIPTION
Update:
**Extern:** The API did not change.
