### PR TITLE
Update semantic-ui-react to 0.67.1

### DIFF
--- a/semantic-ui-react/build.boot
+++ b/semantic-ui-react/build.boot
@@ -8,7 +8,7 @@
          '[clojure.java.io :as io]
          '[boot.util :refer [sh]])
 
-(def +lib-version+ "0.64.7")
+(def +lib-version+ "0.67.1")
 (def +version+ (str +lib-version+ "-0"))
 (def +lib-folder+ (format "semantic-ui-react-%s" +lib-version+))
 
@@ -24,7 +24,7 @@
 
 (deftask download-semantic-ui-react []
   (download :url      url
-            :checksum "2CC9C0846B9A3443D0A213EF11277354"))
+            :checksum "692812D6853450215B17820275822B82"))
 
 (deftask package []
   (comp

--- a/semantic-ui-react/resources/cljsjs/semantic-ui-react/common/semantic-ui-react.ext.js
+++ b/semantic-ui-react/resources/cljsjs/semantic-ui-react/common/semantic-ui-react.ext.js
@@ -1,3 +1,1 @@
-var TopLevel = {
-"semanticUIReact" : function () {}
-}
+var semanticUIReact = {};


### PR DESCRIPTION
Unfortunately I don't have the time to write the externs for this library by hand right now and I also use `goog.object/get` as the original author did. I did clean up the externs to remove the unnecessary `TopLevel` var and update the lib to the latest version.

Update:
**Extern:** The API did not change.