### PR TITLE
[material-components] Include SCSS into jar and document usage

### DIFF
--- a/material-components/README.md
+++ b/material-components/README.md
@@ -15,4 +15,28 @@ you can require the packaged library like:
   (:require [cljsjs.material-components]))
 ```
 
+## Theming
+Because this is largely about design, we would be remiss if we were to
+offer this without some ability to change the theme.
+Following [Non-JS Assets][nonjs] for SASS, you need to set up sass4clj or
+another sass compiler to include the files into your compiled css. Create a SCSS
+file and include the components from the jar that you need:
+
+```sass
+@import "cljsjs/material-components/development/material-components.inc";
+
+$mdc-theme-primary: #9c27b0;
+$mdc-theme-accent: #ffab40;
+$mdc-theme-background: #fff;
+
+@import "cljsjs/material-components/development/packages/mdc-theme/mdc-theme";
+```
+
+Here, I import the base css for all the material components, then I set my theme
+according to the [MDC Theme Package][mdctheme]. There are many more options for
+mixins if you so desire. You would then load the compiled css in your project.
+Et voilà, you are set free to theme away.
+
 [flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies
+[nonjs]: https://github.com/cljsjs/packages/wiki/Non-JS-Assets
+[mdctheme]: https://github.com/material-components/material-components-web/tree/master/packages/mdc-theme

--- a/material-components/build.boot
+++ b/material-components/build.boot
@@ -9,7 +9,7 @@
          '[boot.util :refer [sh]])
 
 (def +lib-version+ "0.6.0")
-(def +version+ (str +lib-version+ "-0"))
+(def +version+ (str +lib-version+ "-1"))
 
 (task-options!
  pom {:project     'cljsjs/material-components
@@ -46,6 +46,8 @@
    (sift :move {(re-pattern (str "^material-components-web-" +lib-version+ "/build/material-components-web.css$")) "cljsjs/material-components/development/material-components.inc.css"})
    (sift :move {(re-pattern (str "^material-components-web-" +lib-version+ "/build/material-components-web.min.js$")) "cljsjs/material-components/production/material-components.min.inc.js"})
    (sift :move {(re-pattern (str "^material-components-web-" +lib-version+ "/build/material-components-web.min.css$")) "cljsjs/material-components/production/material-components.min.inc.css"})
+   (sift :move {(re-pattern (str "^material-components-web-" +lib-version+ "/packages/([^/]*)/([^/]*).scss$"))
+                "cljsjs/material-components/development/packages/$1/$2.scss"})
 
    (sift :include #{#"^cljsjs"})
    (deps-cljs :name "cljsjs.material-components")


### PR DESCRIPTION
Update:

**Extern:** The API did not change.

This is an update to material-components to include the SCSS files from the source so that they can be used in theming the resulting css.  I then include the documentation on how to do that in the README.md.  This should have no breaking changes on current usage and increases the size of the jar by only about 60KiB.