### PR TITLE
react-toolbox: 2.0.0-beta.6 -> 2.0.0-beta.7

### DIFF
--- a/react-toolbox/build.boot
+++ b/react-toolbox/build.boot
@@ -10,7 +10,7 @@
          '[boot.util :refer [sh]]
          '[clojure.java.io :as io])
 
-(def +lib-version+ "2.0.0-beta.6")
+(def +lib-version+ "2.0.0-beta.7")
 (def +version+ (str +lib-version+ "-0"))
 (def +lib-folder+ (format "react-toolbox-%s" +lib-version+))
 
@@ -31,7 +31,7 @@
 
 (deftask download-lib []
          (download :url (format "https://github.com/react-toolbox/react-toolbox/archive/%s.zip" +lib-version+)
-                   :checksum "4992342FB643970C5B76B2B362FDFA13"
+                   :checksum "279AFADA1FCAB344DDC67BD7D0C20F49"
                    :unzip true))
 
 (deftask build []
@@ -46,8 +46,6 @@
                             (io/file tmp +lib-folder+ "webpack-cljsjs.config.js"))
                           (binding [boot.util/*sh-dir* (str (io/file tmp +lib-folder+))]
                             ((sh (cmd "npm") "install"))
-                            ((sh (cmd "npm") "install" "babel-plugin-add-module-exports"))
-                            ((sh (cmd "npm") "run" "build"))
                             ((sh (cmd (path (str (io/file tmp +lib-folder+) "/node_modules/.bin/webpack"))) "--config" "webpack-cljsjs.config.js")))
                           (-> fileset (boot/add-resource tmp) boot/commit!))))
 

--- a/react-toolbox/resources/webpack.config.js
+++ b/react-toolbox/resources/webpack.config.js
@@ -1,64 +1,88 @@
+const pkg = require('./package');
 const path = require('path');
 const webpack = require('webpack');
-const autoprefixer = require('autoprefixer');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
-process.env.NODE_ENV = "production";
 
-var entryName = "react-toolbox.inc";
+const entryName = "react-toolbox.inc";
+
+const extractCss = new ExtractTextPlugin({ filename: entryName + '.css', allChunks: true });
 
 module.exports = {
+    target: 'web',
+    context: __dirname,
     entry: path.join(__dirname, "components", "index.js"),
-
     externals: {
         "react": "React",
-        "react-dom": "ReactDOM"
+        "react-dom": "ReactDOM",
+        "react-addons-css-transition-group": "React.addons.CSSTransitionGroup"
     },
-
     output: {
-        filename: entryName + ".js",
-        libraryTarget: "var",
-        library: "ReactToolbox"
+        path: __dirname,
+        filename: entryName + '.js',
+        libraryTarget: 'var',
+        library: 'ReactToolbox'
     },
-
     resolve: {
-        extensions: ['', '.js', '.jsx', '.scss', ".css"]
+        extensions: ['.js', '.css', '.json'],
+        modules: ['node_modules']
     },
-
     module: {
-        loaders: [
+        rules: [
             {
-                test: /(\.js|\.jsx)$/,
-                exclude: /(node_modules)/,
-                loader: "babel",
-                query: {
-                    presets: ['es2015', 'react', 'stage-0'],
-                    plugins: ['add-module-exports']
-                }
+                test: /\.js$/,
+                use: 'babel-loader',
+                include: [
+                    path.join(__dirname, './components'),
+                    path.join(__dirname, './spec')
+                ]
             }, {
                 test: /\.css$/,
-                include: /node_modules/,
-                loader: ExtractTextPlugin.extract('style', 'css')
-            }, {
-                test: /\.css$/,
-                include: [path.join(__dirname, './components'), path.join(__dirname, './spec')],
-                loader: ExtractTextPlugin.extract('style', 'css?sourceMap&modules&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]!postcss')
+                include: [
+                    path.join(__dirname, './components'),
+                    path.join(__dirname, './spec'),
+                        /node_modules/
+                ],
+                use: extractCss.extract({
+                    fallback: 'style-loader',
+                    use: [
+                        {
+                            loader: 'css-loader',
+                            query: {
+                                modules: true,
+                                localIdentName: '[name]__[local]___[hash:base64:5]',
+                                sourceMap: true
+                            },
+                        },
+                        'postcss-loader'
+                    ]})
             }
         ]
     },
-
-    postcss () {
-        return [
-            require('postcss-import')({
-                root: __dirname,
-                path: [path.join(__dirname, './components')]
-            }),
-            require('postcss-mixins')(),
-            require('postcss-each')(),
-            require('postcss-cssnext')(),
-            require('postcss-reporter')({ clearMessages: true })
-        ];
-    },
     plugins: [
-        new ExtractTextPlugin(entryName + '.css', {allChunks: true})
+        new webpack.LoaderOptionsPlugin({
+            options: {
+                context: __dirname,
+                postcss: function () {
+                    return [
+                        require('postcss-import')({
+                            root: __dirname,
+                            path: [path.join(__dirname, './components')]
+                        }),
+                        require('postcss-mixins')(),
+                        require('postcss-each')(),
+                        require('postcss-cssnext')(),
+                        require('postcss-reporter')({
+                            clearMessages: true
+                        })
+                    ];
+                }
+            }
+        }),
+        extractCss,
+        new webpack.HotModuleReplacementPlugin(),
+        new webpack.DefinePlugin({
+            'process.env.NODE_ENV': JSON.stringify('production'),
+            VERSION: JSON.stringify(pkg.version)
+        })
     ]
 };


### PR DESCRIPTION
Also migrate the webpack config to webpack2, but most important:
Fix an issue, where the currently released beta.6 includes its own
react.
This resolves `owner == null` issues with certain widgets, as well as
reduces the .inc.js size drastically.

Update:

**Extern:** The API did not change.
