### PR TITLE
updating plotly version to 1.25.0

### DIFF
--- a/plotly/README.md
+++ b/plotly/README.md
@@ -2,7 +2,7 @@
 
 [](dependency)
 ```clojure
-[cljsjs/plotly "1.22.0-0"] ;; latest release
+[cljsjs/plotly "1.25.0-0"] ;; latest release
 ```
 [](/dependency)
 

--- a/plotly/build.boot
+++ b/plotly/build.boot
@@ -4,7 +4,7 @@
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
-(def +lib-version+ "1.22.0")
+(def +lib-version+ "1.25.0")
 (def +version+ (str +lib-version+ "-0"))
 
 (task-options!
@@ -18,7 +18,7 @@
 (deftask package []
   (comp
    (download  :url      (format "https://github.com/plotly/plotly.js/archive/v%s.zip" +lib-version+)
-              :checksum "BE66C9CAE94A8272AAD510A57EEAB515"
+              :checksum "60D8CAB903FAF439B7273FD682172350"
               :unzip    true)
    (sift      :move     {#"^plotly(.*)/dist/plotly.js"
                          "cljsjs/plotly/development/plotly.inc.js"


### PR DESCRIPTION
Keep relevant lines. You should select one choice for each category
(e.g. **Extern**), if none of choices is valid you should probably do
something or at least add a comment here.

New package:

**Extern:** Provided by the library.
**Extern:** Generated.
**Extern:** Written by hand.
**Extern:** Not needed as this is Closure library.

Update:

**Extern:** The API did not change.
**Extern:** I updated the extern by hand.
**Extern:** I updated the extern with generator.
**Extern:** Not needed as this is Closure library.
