### PR TITLE
[fixed-data-table] Bump React to 0.14.0

### DIFF
--- a/fixed-data-table/build.boot
+++ b/fixed-data-table/build.boot
@@ -1,13 +1,14 @@
 (set-env!
   :resource-paths #{"resources"}
   :dependencies '[[cljsjs/boot-cljsjs        "0.5.2"  :scope "test"]
-                  [cljsjs/react              "0.13.3-0"]
+                  [cljsjs/react              "0.14.4-0"]
+                  [cljsjs/react-dom          "0.14.4-0"]
                   [cljsjs/object-assign-shim "0.1.0-1"]])
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
 (def +lib-version+ "0.6.3")
-(def +version+ (str +lib-version+ "-0"))
+(def +version+ (str +lib-version+ "-1"))
 
 (task-options!
  pom  {:project     'cljsjs/fixed-data-table
@@ -43,6 +44,6 @@
                  "cljsjs/production/fixed-data-table-style.min.inc.css"})
     (sift :include #{#"^cljsjs"})
     (deps-cljs :name "cljsjs.fixed-data-table"
-               :requires ["cljsjs.react" "cljsjs.object-assign-shim"])
+               :requires ["cljsjs.react", "cljsjs.react.dom", "cljsjs.object-assign-shim"])
     (pom)
     (jar)))


### PR DESCRIPTION
Some of the functionality in 0.6.3 depends on `ReactDOM`
being present:

https://github.com/facebook/fixed-data-table/blob/master/package.json

Update:

**Extern:** The API did not change.
