### PR TITLE
Add str/trim-newline to react-relay README.md

### DIFF
--- a/react-relay/README.md
+++ b/react-relay/README.md
@@ -24,13 +24,14 @@ Because ClojureScript has macros, we can use them to shell out to Node, like thi
 (ns my.project.relay ; .clj macro file
   (:require
    [clojure.java.io :as io]
+   [clojure.string :as str]
    [me.raynes.conch :as conch]))
 
 (defn ^:private ql* [env query]
   (let [filename (-> env :ns :name)
         {:keys [line column]} env
         code (str  "/* " filename " " line " " column "*/" ; unique key for every query
-                   "Relay.QL`" query "`")
+                   "Relay.QL`" (str/replace query #"\r\n|\n|\r" " ") "`;")
         schema (-> "relay/schema.json" io/resource slurp) ; GraphQL schema from introspection query
         script (str "var schema = " schema ";"
                     "var schemaData = schema.data;"


### PR DESCRIPTION
This PR makes the example in the react-relay README.md a bit more
bulletproof. The example didn't handle GraphQL fragments with newlines
in them, causing the Node process to fail.