### PR TITLE
[firebase] Add existing externs to externs vector

### DIFF
--- a/firebase/resources/deps.cljs
+++ b/firebase/resources/deps.cljs
@@ -6,4 +6,5 @@
            "cljsjs/common/firebase-storage-externs.js"
            "cljsjs/common/firebase-auth-externs.js"
            "cljsjs/common/firebase-server-auth-externs.js"
+           "cljsjs/common/firebase-client-auth-externs.js"
            "cljsjs/common/firebase-app-externs.js"]}


### PR DESCRIPTION
**Extern:** The API did not change.

This externs file is already included in the upstream externs, but it was
previously excluded from the CLJS externs declaration.  This adds it
so that OAuth logins will work in the browser.