### PR TITLE
[firebase] Add existing externs to CLJS externs declaration

### DIFF
--- a/firebase/build.boot
+++ b/firebase/build.boot
@@ -5,7 +5,7 @@
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
 (def +lib-version+ "3.5.3")
-(def +version+ (str +lib-version+ "-0"))
+(def +version+ (str +lib-version+ "-1"))
 
 (task-options!
  pom  {:project     'cljsjs/firebase

--- a/firebase/resources/deps.cljs
+++ b/firebase/resources/deps.cljs
@@ -6,4 +6,5 @@
            "cljsjs/common/firebase-storage-externs.js"
            "cljsjs/common/firebase-auth-externs.js"
            "cljsjs/common/firebase-server-auth-externs.js"
+           "cljsjs/common/firebase-client-auth-externs.js"
            "cljsjs/common/firebase-app-externs.js"]}


### PR DESCRIPTION
This externs file is already included in the upstream externs, but it was
previously excluded from the CLJS externs declaration.  This adds it
so that OAuth logins will work in the browser.

**Extern:** The API did not change.
