### PR TITLE
Remove test and demo files from libphonenumber

### DIFF
--- a/libphonenumber/build.boot
+++ b/libphonenumber/build.boot
@@ -5,7 +5,7 @@
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
 (def +lib-version+ "8.4.1")
-(def +version+ (str +lib-version+ "-0"))
+(def +version+ (str +lib-version+ "-1"))
 
 (task-options!
  pom  {:project     'cljsjs/libphonenumber
@@ -22,6 +22,9 @@
               :unzip true)
     (show :fileset true)
     (sift :move {#"^libphonenumber-[\d\.]*/javascript/i18n/phonenumbers/" "cljsjs/libphonenumber/development/i18n/"})
+    (sift :include #{#"cljsjs/libphonenumber/.*test"
+                     #"cljsjs/libphonenumber/.*demo"}
+          :invert true)
     (sift :include #{#"^cljsjs/" #"deps.cljs"})
     (pom)
     (jar)))


### PR DESCRIPTION
Some of those files have the same goog.provide and define the same symbols (with different content) as the "main" files, creating errors due to the wrong version of some symbols being loaded.

An example of these duplicate symbols is `i18n.phonenumbers.metadata.countryCodeToRegionCodeMap` defined both in [metadata.js](https://github.com/googlei18n/libphonenumber/blob/57cb83dc236c6103057d54591cdbcc8a8309226e/javascript/i18n/phonenumbers/metadata.js#L33-L248) and [metadatafortesting.js](https://github.com/googlei18n/libphonenumber/blob/57cb83dc236c6103057d54591cdbcc8a8309226e/javascript/i18n/phonenumbers/metadatafortesting.js#L33-L61)

This example of metadatafortesting.js defines a country to metadata
mapping for a reduced set of countries. When this mapping ends being
loaded instead of the main one, users of this library might get errors like
"invalid country calling code" for otherwise valid country codes. This reduced
country set metadata seems useful during testing of libphonenumber as it must
load faster, but testing the libphonenumber library itself is not the intended usage of the
cljsjs package.

I'm not sure what determines which version of the duplicate symbols is the
one that ends being used, it seems to me that it depends on a
non-deterministic loading order during compilation at some stage of the
google closure compiler run. What's clear to me is that having two files
to define the same symbol with different meanings under the same
goog.provide is ambiguous at the very least.

---
**Extern:** Not needed as this is Closure library.
