### PR TITLE
vega-embed 3.0.0-beta.14

### DIFF
--- a/vega-embed/build.boot
+++ b/vega-embed/build.boot
@@ -2,11 +2,11 @@
   :resource-paths #{"resources"}
   :dependencies '[[cljsjs/boot-cljsjs "0.5.2" :scope "test"]
                   [cljsjs/vega "3.0.0-beta.30-0"]
-                  [cljsjs/vega-lite "2.0.0-beta.1-0"]])
+                  [cljsjs/vega-lite "2.0.0-beta.2-0"]])
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
-(def +lib-version+ "3.0.0-beta.11")
+(def +lib-version+ "3.0.0-beta.14")
 
 (def +version+ (str +lib-version+ "-0"))
 
@@ -23,7 +23,7 @@
     (download
       :url (str "https://github.com/vega/vega-embed/archive/v" +lib-version+ ".zip")
       :unzip true
-      :checksum "de7699c59ba13189a828da195bf0646d")
+      :checksum "a3785a96d631458ac50f0c632ab35a39")
     (sift :move {(re-pattern (str "^vega-embed-" +lib-version+ "/vega-embed.js$")) "cljsjs/development/vega-embed.inc.js"
                  (re-pattern (str "^vega-embed-" +lib-version+ "/vega-embed.min.js$")) "cljsjs/production/vega-embed.min.inc.js"})
     (sift :include #{#"^cljsjs"})


### PR DESCRIPTION
vega-embed 3.0.0-beta.14

Update:

**Extern:** The API did not change.
