### PR TITLE
Update auth0-lock to 10.16.0

### DIFF
--- a/auth0-lock/README.md
+++ b/auth0-lock/README.md
@@ -2,7 +2,7 @@
 
 [](dependency)
 ```clojure
-[cljsjs/auth0-lock "10.13.0-0"] ;; latest release
+[cljsjs/auth0-lock "10.16.0-0"] ;; latest release
 ```
 [](/dependency)
 

--- a/auth0-lock/build.boot
+++ b/auth0-lock/build.boot
@@ -4,7 +4,7 @@
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
-(def +lib-version+ "10.13.0")
+(def +lib-version+ "10.16.0")
 (def +version+ (str +lib-version+ "-0"))
 
 (task-options!


### PR DESCRIPTION
Update:

Updated version to latest 10.16.0

**Extern:** The API did not change.
