### PR TITLE
Fix typo in jspdf readme file

### DIFF
--- a/jspdf/README.md
+++ b/jspdf/README.md
@@ -6,4 +6,4 @@
 ```
 [](/dependency)
 
-CLJSJS package for [jsPDF](https://parall.ax/products/jspdf). See hhttp://mrrio.github.io/doc/symbols/jsPDF.html for documentation.
+CLJSJS package for [jsPDF](https://parall.ax/products/jspdf). See http://mrrio.github.io/doc/symbols/jsPDF.html for documentation.


### PR DESCRIPTION
None of the pre-suggested lines seemed relevant. All I did was change the md file.