### PR TITLE
PDFJS upgrade to 1.8.188

### DIFF
--- a/pdfjs/README.md
+++ b/pdfjs/README.md
@@ -2,7 +2,7 @@
 
 [](dependency)
 ```clojure
-[cljsjs/pdfjs "1.5.188-0"] ;; latest release
+[cljsjs/pdfjs "1.8.188-0"] ;; latest release
 ```
 [](/dependency)
 

--- a/pdfjs/build.boot
+++ b/pdfjs/build.boot
@@ -4,7 +4,7 @@
 
 (require '[cljsjs.boot-cljsjs.packaging :refer [download]])
 
-(def +lib-version+ "1.5.188")
+(def +lib-version+ "1.8.188")
 (def +version+ (str +lib-version+ "-0"))
 
 (task-options!
@@ -18,7 +18,7 @@
 (deftask package []
   (comp
     (download :url (format "https://github.com/mozilla/pdf.js/releases/download/v%s/pdfjs-%s-dist.zip" +lib-version+ +lib-version+)
-              :checksum "8646FE88211233E120C28613483D095C"
+              :checksum "E222E1FECE6A8672DFD2A91F04FD743E"
               :unzip true)
     (sift :move {#"^build/pdf\.js$"         "cljsjs/pdfjs/common/pdf.inc.js"
                  #"^build/pdf\.worker\.js$" "cljsjs/pdfjs/common/pdf.worker.inc.js"


### PR DESCRIPTION
**Extern:** The API did not change.

