### PR TITLE
Adding a currency formatting component

### DIFF
--- a/react-number-format/README.md
+++ b/react-number-format/README.md
@@ -1,0 +1,18 @@
+# cljsjs/react-number-format
+
+[](dependency)
+```clojure
+[cljsjs/react-number-format "2.0.0-alpha2"] ;; latest release
+```
+[](/dependency)
+
+This jar comes with `deps.cljs` as used by the [Foreign Libs][flibs] feature
+of the ClojureScript compiler. After adding the above dependency to your project
+you can require the packaged library like so:
+
+```clojure
+(ns application.core
+  (:require cljsjs.react-number-format))
+```
+
+[flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies

--- a/react-number-format/build.boot
+++ b/react-number-format/build.boot
@@ -1,0 +1,38 @@
+(set-env!
+  :resource-paths #{"resources"}
+  :dependencies '[[cljsjs/boot-cljsjs "0.5.2"  :scope "test"]
+                  [cljsjs/react "15.3.1-0"]])
+
+(require '[cljsjs.boot-cljsjs.packaging :refer :all])
+
+(def +lib-version+ "2.0.0")
+(def +version+ (str +lib-version+ "-alpha2"))
+
+(task-options!
+ pom  {:project     'cljsjs/react-number-format
+       :version     +version+
+       :description "Yet another react component for input masking"
+       :url         "https://github.com/s-yadav/react-number-format"
+       :scm         {:url "https://github.com/cljsjs/packages"}
+       :license     {"MIT" "http://opensource.org/licenses/MIT"}})
+
+(require '[boot.core :as c]
+         '[boot.tmpdir :as tmpd]
+         '[clojure.java.io :as io]
+         '[clojure.string :as string])
+
+(deftask package []
+  (comp
+   (download :url (str "https://github.com/s-yadav/react-number-format/archive/v2.0.0-alpha2.zip")
+
+     :unzip true)
+
+   (sift :move {#"^react-number-format-.*[/ \\]dist[/ \\]react-number-format.js$" "cljsjs/react-number-format/development/react-number-format.inc.js"
+                #"^react-number-format-.*[/ \\]dist[/ \\]react-number-format.min.js$" "cljsjs/react-number-format/production/react-number-format.min.inc.js"})
+   (sift :include #{#"^cljsjs"})
+
+   (deps-cljs :name "cljsjs.react-number-format"
+              :requires ["cljsjs.react"
+                         "cljsjs.classnames"])
+   (pom)
+   (jar)))

--- a/react-number-format/build.boot
+++ b/react-number-format/build.boot
@@ -5,8 +5,8 @@
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
-(def +lib-version+ "2.0.0")
-(def +version+ (str +lib-version+ "-alpha2"))
+(def +lib-version+ "v2.0.0-alpha2")
+(def +version+ (str +lib-version+ "-0"))
 
 (task-options!
  pom  {:project     'cljsjs/react-number-format
@@ -23,7 +23,7 @@
 
 (deftask package []
   (comp
-   (download :url (str "https://github.com/s-yadav/react-number-format/archive/v2.0.0-alpha2.zip")
+   (download :url (format "https://github.com/s-yadav/react-number-format/archive/%s.zip" +lib-version+)
 
      :unzip true)
 

--- a/react-number-format/resources/cljsjs/react-number-format/common/react-number-format.ext.js
+++ b/react-number-format/resources/cljsjs/react-number-format/common/react-number-format.ext.js
@@ -1,0 +1,39 @@
+var NumberFormat = {
+  "propTypes": {
+    "thousandSeparator": {
+      "isRequired": function () {}
+    },
+    "decimalSeparator": {
+      "isRequired": function () {}
+    },
+    "decimalPrecision": {
+      "isRequired": function () {}
+    },
+    "displayType": {
+      "isRequired": function () {}
+    },
+    "prefix": {
+      "isRequired": function () {}
+    },
+    "suffix": {
+      "isRequired": function () {}
+    },
+    "format": {
+      "isRequired": function () {}
+    },
+    "mask": {
+      "isRequired": function () {}
+    },
+    "value": {
+      "isRequired": function () {}
+    },
+    "customInput": {
+      "isRequired": function () {}
+    }
+  },
+  "defaultProps": {
+    "displayType": {},
+    "decimalSeparator": {},
+    "decimalPrecision": {}
+  }
+};


### PR DESCRIPTION
Keep relevant lines. You should select one choice for each category
(e.g. **Extern**), if none of choices is valid you should probably do
something or at least add a comment here.

New package: react-number-format

**Extern:** Written by hand.

Update:

