### PR TITLE
React surrogate

### DIFF
--- a/react/build.boot
+++ b/react/build.boot
@@ -72,11 +72,8 @@
   (with-files (fn [x] (= extern-name (.getName (tmp-file x))))
     (comp
      (if surrogate?
-       (comp
-        (surrogate :filename (format "cljsjs/%1$s/development/%1$s.inc.js" (name project))
-                   :project project)
-        (surrogate :filename (format "cljsjs/%1$s/production/%1$s.min.inc.js" (name project))
-                   :project project))
+       (surrogate :filename (format "cljsjs/%1$s/development/%1$s.inc.js" (name project))
+                  :project project)
        (comp
         (download :url (format "https://unpkg.com/%s@%s/dist/%s.js" (npm-project project) +lib-version+ (name project))
                   :checksum (:dev (get checksums project)))


### PR DESCRIPTION
This PR adds surrogate packages for cljsjs/react, cljsjs/react-dom and cljsjs/react-dom-server. These packages are like their non-surrogate counterparts, except that the contained javascript file is empty. The packages do contain externs for React.

Libraries like reagent require the `cljsjs.react`, `cljsjs.react.dom` and `cljsjs.react.dom.server` namespaces. If you use a Rect version provided by some other means, you need to make sure these requires don't fail. A common way to do this is to faux `src/cljsjs/react.cljs` etc. files containing empty namespaces.

With this PR, you can add these coordinates to your project.clj instead:

```
[cljsjs/react-surrogate "15.5.4-0"]
[cljsjs/react-dom-surrogate "15.5.4-0"]
[cljsjs/react-dom-server-surrogate "15.5.4-0"]
```

This is a cleaner solution than adding empty namespaces. Note that you also need to exclude all cljsjs react packages. The best way is to add global exclusions:

```
:exclusions [cljsjs/react cljsjs/react-dom cljsjs/react-dom-server]
```