### PR TITLE
Update filestack to V3

### DIFF
--- a/filestack/README.md
+++ b/filestack/README.md
@@ -2,7 +2,7 @@
 
 [](dependency)
 ```clojure
-[cljsjs/filestack "2.4.10-0"] ;; latest release
+[cljsjs/filestack "0.6.3-0"] ;; latest release
 ```
 [](/dependency)
 

--- a/filestack/build.boot
+++ b/filestack/build.boot
@@ -4,7 +4,7 @@
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
-(def +lib-version+ "2.4.10")
+(def +lib-version+ "0.6.3")
 (def +version+ (str +lib-version+ "-0"))
 
 (task-options!
@@ -16,12 +16,9 @@
 
 (deftask package []
   (comp
-   (download :url (str "https://api.filestackapi.com/filestack-" +lib-version+ ".min.js")
-             :checksum "6F242D61B55D20BC4F9DB053D01C5A1C")
-   (download :url (str "https://api.filestackapi.com/filestack-" +lib-version+ ".js")
-             :checksum "FCA7F73803085DA47B4C5EBE9C007E5D")
-   (sift :move {#"^filestack-\d+\.\d+\.\d+\.min\.js$" "cljsjs/filestack/production/filestack.min.inc.js"
-                #"^filestack-\d+\.\d+\.\d+\.js$" "cljsjs/filestack/development/filestack.inc.js"})
+   (download :url (str "http://static.filestackapi.com/v3/filestack-" +lib-version+ ".js")
+             :checksum "6A2BBF6B6799E044C1EC0B5D65B99385")
+   (sift :move {#"^filestack-\d+\.\d+\.\d+\.js$" "cljsjs/filestack/development/filestack.inc.js"})
    (target)
    (sift :include #{#"^cljsjs"})
    (deps-cljs :name "cljsjs.filestack")

--- a/filestack/resources/cljsjs/filestack/common/filestack.ext.js
+++ b/filestack/resources/cljsjs/filestack/common/filestack.ext.js
@@ -1,30 +1,4 @@
-var filepicker = {
-  "errors": {},
-  "setKey": function () {},
-  "setResponsiveOptions": function () {},
-  "pick": function () {},
-  "pickFolder": function () {},
-  "pickMultiple": function () {},
-  "pickAndStore": function () {},
-  "read": function () {},
-  "write": function () {},
-  "writeUrl": function () {},
-  "export": function () {},
-  "exportFile": function () {},
-  "processImage": function () {},
-  "store": function () {},
-  "storeUrl": function () {},
-  "stat": function () {},
-  "metadata": function () {},
-  "remove": function () {},
-  "convert": function () {},
-  "constructWidget": function () {},
-  "makeDropPane": function () {},
-  "FilepickerException": {
-    "isClass": {}
-  },
-  "responsive": function () {},
-  "version": {},
-  "services": {},
-  "base64": {}
+var filestack = {
+  "init": function () {},
+  "version": {}
 };


### PR DESCRIPTION
Update version to 0.6.3 which is the latest for Filestack V3.

**Breaking changes**
Reference for new version can be found here https://github.com/filestack/filestack-js
Migration guide: https://www.filestack.com/docs/javascript-api/migrating-to-v3

**Extern:** I updated the extern with generator. (https://jmmk.github.io/javascript-externs-generator/)
