### PR TITLE
[material-ui-chip-input] Update to version 0.15.0

### DIFF
--- a/material-ui-chip-input/README.md
+++ b/material-ui-chip-input/README.md
@@ -2,7 +2,7 @@
 
 [](dependency)
 ```clojure
-[cljsjs/material-ui-chip-input "0.13.5-0"] ;; latest release
+[cljsjs/material-ui-chip-input "0.15.0-0"] ;; latest release
 ```
 [](/dependency)
 

--- a/material-ui-chip-input/build.boot
+++ b/material-ui-chip-input/build.boot
@@ -3,7 +3,7 @@
   :dependencies '[[cljsjs/boot-cljsjs "0.5.2"  :scope "test"]
                   [cljsjs/material-ui "0.18.0-0"]])
 
-(def +lib-version+ "0.13.5")
+(def +lib-version+ "0.15.0")
 (def +version+ (str +lib-version+ "-0"))
 (def +lib-folder+ (format "material-ui-chip-input-%s" +lib-version+))
 
@@ -25,7 +25,7 @@
 
 (deftask download-material-ui-chip-input []
          (download :url url
-                   :checksum "b13899d60abeb648390fe2eac75a7484"
+                   :checksum "a3d9f18552f65ef86bd14d03ad29a29c"
                    :unzip true))
 
 (def webpack-file-name "webpack.config.js")


### PR DESCRIPTION
**Extern:** The API did not change.

