### PR TITLE
Add cljsjs.react.dom as a dependency for fixed-data-table-2

### DIFF
--- a/fixed-data-table-2/README.md
+++ b/fixed-data-table-2/README.md
@@ -2,7 +2,7 @@
 
 [](dependency)
 ```clojure
-[cljsjs/fixed-data-table-2 "0.7.17-1"] ;; latest release
+[cljsjs/fixed-data-table-2 "0.7.17-2"] ;; latest release
 ```
 [](/dependency)
 

--- a/fixed-data-table-2/build.boot
+++ b/fixed-data-table-2/build.boot
@@ -8,7 +8,7 @@
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
 (def +lib-version+ "0.7.17")
-(def +version+ (str +lib-version+ "-1"))
+(def +version+ (str +lib-version+ "-2"))
 
 (task-options!
  pom  {:project     'cljsjs/fixed-data-table-2
@@ -44,7 +44,7 @@
                  "cljsjs/production/fixed-data-table-style.min.inc.css"})
     (sift :include #{#"^cljsjs"})
     (deps-cljs :name "cljsjs.fixed-data-table-2"
-               :requires ["cljsjs.react" "cljsjs.object-assign-shim"])
+               :requires ["cljsjs.react" "cljsjs.react.dom" "cljsjs.object-assign-shim"])
     (pom)
     (jar)))
 


### PR DESCRIPTION
This library tries to use "findDOMNode" from cljsjs.react.dom, but hasn't declared a dependency on it. This results in runtime errors if cljsjs.react.dom has not been loaded before (which is probably why this has gone unnoticed so far).
