### PR TITLE
Update Recharts to most recent stable version (0.22.4)

### DIFF
--- a/recharts/build.boot
+++ b/recharts/build.boot
@@ -20,7 +20,7 @@
        :license     {"MIT" "https://raw.githubusercontent.com/react-bootstrap/react-bootstrap/master/LICENSE"}})
 
 (deftask build-recharts []
-  (let [tmp (c/temp-dir!)]
+  (let [tmp (c/tmp-dir!)]
     (with-pre-wrap
       fileset
                                         ; Copy all files in fileset to temp directory

--- a/recharts/build.boot
+++ b/recharts/build.boot
@@ -8,7 +8,7 @@
          '[clojure.java.io :as io]
          '[cljsjs.boot-cljsjs.packaging :refer :all])
 
-(def +lib-version+ "0.21.2")
+(def +lib-version+ "0.22.4")
 (def +version+ (str +lib-version+ "-0"))
 
 (task-options!
@@ -37,7 +37,7 @@
   (comp
    (download :url (format "https://github.com/recharts/recharts/archive/v%s.zip" +lib-version+)
              :unzip true
-             :checksum "CD48B2810D6C26614F6A42009D632F02")
+             :checksum "F4C6026BE9EC65693A14935FCA67132E")
    (sift :move {#"^recharts-\d?\.\d*?\.\d?/" ""})
    (build-recharts)
    (sift :move {#"umd/Recharts\.js" "cljsjs/recharts/development/Recharts.inc.js"


### PR DESCRIPTION
Update:

**Extern:** The API did not change.