### PR TITLE
Fix links in mathbox/readme

### DIFF
--- a/mathbox/README.md
+++ b/mathbox/README.md
@@ -6,7 +6,7 @@
 ```
 [](/dependency)
 
-ClojureScript package for the [MathBox](mathbox) mathematical visualization library. Note that this is MathBox 1, not the very different [MathBox 2](mathbox2) library by the same author, which is in alpha release as of this writing. Author is also preparing a cljs-mathbox library for Clojars, which is an idiomatic(ish) cljs wrapper for MathBox.
+ClojureScript package for the [MathBox][mathbox] mathematical visualization library. Note that this is MathBox 1, not the very different [MathBox 2][mathbox2] library by the same author, which is in alpha release as of this writing. Author is also preparing a cljs-mathbox library for Clojars, which is an idiomatic(ish) cljs wrapper for MathBox.
 
 This jar comes with `deps.cljs` as used by the [Foreign Libs][flibs] feature
 of the ClojureScript compiler. After adding the above dependency to your project


### PR DESCRIPTION
Just fixed a typo [txt](link_id) -> [txt][link_id].