### PR TITLE
React :global-exports support

### DIFF
--- a/create-react-class/build.boot
+++ b/create-react-class/build.boot
@@ -5,7 +5,7 @@
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
 (def +lib-version+ "15.6.0")
-(def +version+ (str +lib-version+ "-0"))
+(def +version+ (str +lib-version+ "-1-SNAPSHOT"))
 
 (task-options!
  pom  {:project     'cljsjs/create-react-class
@@ -23,7 +23,5 @@
               :checksum "220EE670C19A1C2CDD96E4AE13C7B4F1")
     (sift :move {#"^create-react-class\.js$"      "cljsjs/create-react-class/development/create-react-class.inc.js"
                  #"^create-react-class\.min\.js$" "cljsjs/create-react-class/development/create-react-class.min.inc.js"})
-    (deps-cljs :name "cljsjs.create-react-class"
-               :requires ["cljsjs.react"])
     (pom)
     (jar)))

--- a/create-react-class/build.boot
+++ b/create-react-class/build.boot
@@ -5,7 +5,7 @@
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
 (def +lib-version+ "15.6.0")
-(def +version+ (str +lib-version+ "-1-SNAPSHOT"))
+(def +version+ (str +lib-version+ "-1"))
 
 (task-options!
  pom  {:project     'cljsjs/create-react-class

--- a/create-react-class/resources/deps.cljs
+++ b/create-react-class/resources/deps.cljs
@@ -1,0 +1,11 @@
+{:foreign-libs [{:file "cljsjs/create-react-class/development/create-react-class.inc.js"
+                 :provides ["create-react-class"]
+                 :requires ["react"]
+                 :js-global "createReactClass"
+                 :file-min "cljsjs/create-react-class/production/create-react-class.min.inc.js"}
+                {:file "cljsjs/create-react-class/development/create-react-class.inc.js"
+                 :provides ["cljsjs.create-react-class"]
+                 :requires ["cljsjs.react"]
+                 :file-min "cljsjs/create-react-class/production/create-react-class.min.inc.js"}]
+ :externs ["cljsjs/create-react-class/common/create-react-class.ext.js"]}
+

--- a/create-react-class/resources/deps.cljs
+++ b/create-react-class/resources/deps.cljs
@@ -1,7 +1,7 @@
 {:foreign-libs [{:file "cljsjs/create-react-class/development/create-react-class.inc.js"
                  :provides ["create-react-class"]
                  :requires ["react"]
-                 :js-global "createReactClass"
+                 :global-exports '{create-react-class createReactClass}
                  :file-min "cljsjs/create-react-class/production/create-react-class.min.inc.js"}
                 {:file "cljsjs/create-react-class/development/create-react-class.inc.js"
                  :provides ["cljsjs.create-react-class"]

--- a/create-react-class/resources/deps.cljs
+++ b/create-react-class/resources/deps.cljs
@@ -1,7 +1,7 @@
 {:foreign-libs [{:file "cljsjs/create-react-class/development/create-react-class.inc.js"
                  :provides ["create-react-class"]
                  :requires ["react"]
-                 :global-exports '{create-react-class createReactClass}
+                 :global-exports {create-react-class createReactClass}
                  :file-min "cljsjs/create-react-class/production/create-react-class.min.inc.js"}
                 {:file "cljsjs/create-react-class/development/create-react-class.inc.js"
                  :provides ["cljsjs.create-react-class"]

--- a/react/build.boot
+++ b/react/build.boot
@@ -5,7 +5,7 @@
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
 (def +lib-version+ "15.6.1")
-(def +version+ (str +lib-version+ "-1-SNAPSHOT"))
+(def +version+ (str +lib-version+ "-1"))
 
 (def checksums
   {'cljsjs/react

--- a/react/resources/cljsjs/react/common/react.js
+++ b/react/resources/cljsjs/react/common/react.js
@@ -1,3 +1,0 @@
-goog.provide("react");
-goog.require("cljsjs.react");
-react = window.React;

--- a/react/resources/cljsjs/react/common/react.js
+++ b/react/resources/cljsjs/react/common/react.js
@@ -1,0 +1,3 @@
+goog.provide("react");
+goog.require("cljsjs.react");
+react = window.React;

--- a/react/resources/react-deps.cljs
+++ b/react/resources/react-deps.cljs
@@ -1,0 +1,10 @@
+{:foreign-libs [{:file "cljsjs/react/development/react.inc.js"
+                 :provides ["react"]
+                 :js-global "React"
+                 :file-min "cljsjs/react/production/react.min.inc.js"}
+                {:file "cljsjs/react/development/react.inc.js"
+                 :provides ["cljsjs.react"]
+                 :file-min "cljsjs/react/production/react.min.inc.js"}]
+ :externs ["cljsjs/react/common/react.ext.js"]
+ ; :libs ["cljsjs/react/common/react.js"]
+ }

--- a/react/resources/react-deps.cljs
+++ b/react/resources/react-deps.cljs
@@ -1,6 +1,6 @@
 {:foreign-libs [{:file "cljsjs/react/development/react.inc.js"
                  :provides ["react"]
-                 :global-exports '{react React}
+                 :global-exports {react React}
                  :file-min "cljsjs/react/production/react.min.inc.js"}
                 {:file "cljsjs/react/development/react.inc.js"
                  :provides ["cljsjs.react"]

--- a/react/resources/react-deps.cljs
+++ b/react/resources/react-deps.cljs
@@ -5,6 +5,4 @@
                 {:file "cljsjs/react/development/react.inc.js"
                  :provides ["cljsjs.react"]
                  :file-min "cljsjs/react/production/react.min.inc.js"}]
- :externs ["cljsjs/react/common/react.ext.js"]
- ; :libs ["cljsjs/react/common/react.js"]
- }
+ :externs ["cljsjs/react/common/react.ext.js"]}

--- a/react/resources/react-deps.cljs
+++ b/react/resources/react-deps.cljs
@@ -1,6 +1,6 @@
 {:foreign-libs [{:file "cljsjs/react/development/react.inc.js"
                  :provides ["react"]
-                 :js-global "React"
+                 :global-exports '{react React}
                  :file-min "cljsjs/react/production/react.min.inc.js"}
                 {:file "cljsjs/react/development/react.inc.js"
                  :provides ["cljsjs.react"]

--- a/react/resources/react-dom-deps.cljs
+++ b/react/resources/react-dom-deps.cljs
@@ -1,0 +1,11 @@
+{:foreign-libs [{:file "cljsjs/react-dom/development/react-dom.inc.js"
+                 :provides ["react-dom"]
+                 :requires ["react"]
+                 :js-global "ReactDOM"
+                 :file-min "cljsjs/react-dom/production/react-dom.min.inc.js"}
+                {:file "cljsjs/react-dom/development/react-dom.inc.js"
+                 :provides ["cljsjs.react.dom"]
+                 :requires ["cljsjs.react"]
+                 :file-min "cljsjs/react-dom/production/react-dom.min.inc.js"}]
+ :externs ["cljsjs/react-dom/common/react-dom.ext.js"]}
+

--- a/react/resources/react-dom-deps.cljs
+++ b/react/resources/react-dom-deps.cljs
@@ -8,4 +8,3 @@
                  :requires ["cljsjs.react"]
                  :file-min "cljsjs/react-dom/production/react-dom.min.inc.js"}]
  :externs ["cljsjs/react-dom/common/react-dom.ext.js"]}
-

--- a/react/resources/react-dom-deps.cljs
+++ b/react/resources/react-dom-deps.cljs
@@ -1,7 +1,7 @@
 {:foreign-libs [{:file "cljsjs/react-dom/development/react-dom.inc.js"
                  :provides ["react-dom"]
                  :requires ["react"]
-                 :js-global "ReactDOM"
+                 :global-exports '{react-dom/server ReactDOM}
                  :file-min "cljsjs/react-dom/production/react-dom.min.inc.js"}
                 {:file "cljsjs/react-dom/development/react-dom.inc.js"
                  :provides ["cljsjs.react.dom"]

--- a/react/resources/react-dom-deps.cljs
+++ b/react/resources/react-dom-deps.cljs
@@ -1,7 +1,7 @@
 {:foreign-libs [{:file "cljsjs/react-dom/development/react-dom.inc.js"
                  :provides ["react-dom"]
                  :requires ["react"]
-                 :global-exports '{react-dom/server ReactDOM}
+                 :global-exports {react-dom ReactDOM}
                  :file-min "cljsjs/react-dom/production/react-dom.min.inc.js"}
                 {:file "cljsjs/react-dom/development/react-dom.inc.js"
                  :provides ["cljsjs.react.dom"]

--- a/react/resources/react-dom-server-deps.cljs
+++ b/react/resources/react-dom-server-deps.cljs
@@ -1,7 +1,7 @@
 {:foreign-libs [{:file "cljsjs/react-dom-server/development/react-dom-server.inc.js"
                  :provides ["react-dom/server"]
                  :requires ["react"]
-                 :global-exports '{react-dom/server ReactDOMServer}
+                 :global-exports {react-dom/server ReactDOMServer}
                  :file-min "cljsjs/react-dom-server/production/react-dom-server.min.inc.js"}
                 {:file "cljsjs/react-dom-server/development/react-dom-server.inc.js"
                  :provides ["cljsjs.react.dom.server"]

--- a/react/resources/react-dom-server-deps.cljs
+++ b/react/resources/react-dom-server-deps.cljs
@@ -1,0 +1,11 @@
+{:foreign-libs [{:file "cljsjs/react-dom-server/development/react-dom-server.inc.js"
+                 :provides ["react-dom/server"]
+                 :requires ["react"]
+                 :js-global "ReactDOMServer"
+                 :file-min "cljsjs/react-dom-server/production/react-dom-server.min.inc.js"}
+                {:file "cljsjs/react-dom-server/development/react-dom-server.inc.js"
+                 :provides ["cljsjs.react.dom.server"]
+                 :requires ["cljsjs.react"]
+                 :file-min "cljsjs/react-dom-server/production/react-dom-server.min.inc.js"}]
+ :externs ["cljsjs/react-dom-server/common/react-dom-server.ext.js"]}
+

--- a/react/resources/react-dom-server-deps.cljs
+++ b/react/resources/react-dom-server-deps.cljs
@@ -8,4 +8,3 @@
                  :requires ["cljsjs.react"]
                  :file-min "cljsjs/react-dom-server/production/react-dom-server.min.inc.js"}]
  :externs ["cljsjs/react-dom-server/common/react-dom-server.ext.js"]}
-

--- a/react/resources/react-dom-server-deps.cljs
+++ b/react/resources/react-dom-server-deps.cljs
@@ -1,7 +1,7 @@
 {:foreign-libs [{:file "cljsjs/react-dom-server/development/react-dom-server.inc.js"
                  :provides ["react-dom/server"]
                  :requires ["react"]
-                 :js-global "ReactDOMServer"
+                 :global-exports '{react-dom/server ReactDOMServer}
                  :file-min "cljsjs/react-dom-server/production/react-dom-server.min.inc.js"}
                 {:file "cljsjs/react-dom-server/development/react-dom-server.inc.js"
                  :provides ["cljsjs.react.dom.server"]


### PR DESCRIPTION
New Cljs supports `:global-exports` option on foreign-libs which will allow using normal `:require` to access JS objects from foreign libs:

```
;; foreign-lib
:global-exports {react-dom ReactDOM}

;; cljs
(ns ... (:require [react-dom :as react-dom]))

(react-dom/render ...)
;; => window.ReactDOM.render(...)
;; or something similar
```

This change keeps the existing `cljsjs.react` & co namespaces but adds new, which use the same names as Node packages, for easy transition:

- cljsjs.react -> react
- cljsjs.react.dom -> react-dom
- cljsjs.react.dom.server -> react-dom/server
- cljsjs.create-react-class -> create-react-class