### PR TITLE
Update Raven to 3.17.0

### DIFF
--- a/raven/build.boot
+++ b/raven/build.boot
@@ -4,7 +4,7 @@
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
-(def +lib-version+ "3.16.1")
+(def +lib-version+ "3.17.0")
 (def +version+ (str +lib-version+ "-0"))
 
 (task-options!
@@ -18,7 +18,7 @@
 (deftask package []
   (comp
     (download :url (format "https://github.com/getsentry/raven-js/archive/%s.zip" +lib-version+)
-              :checksum "8D8093CBEE7D35C3E175FBB6ACF06E68"
+              :checksum "A8B10CF7BBAC2D1033A9835C96A7BF9B"
               :unzip true)
     (sift :move { #"^raven-js.*/dist/raven\.js$"      "cljsjs/raven/development/raven.inc.js"
                   #"^raven-js.*/dist/raven\.min\.js$" "cljsjs/raven/production/raven.min.inc.js" })


### PR DESCRIPTION
Update:

**Extern:** I updated the extern with generator.

The extern doesn't change from version 3.16.1. This is just meant to get the latest version.