### PR TITLE
Bump semantic-ui-react to 0.71.4

### DIFF
--- a/semantic-ui-react/build.boot
+++ b/semantic-ui-react/build.boot
@@ -10,7 +10,7 @@
          '[clojure.java.io :as io]
          '[boot.util :refer [sh]])
 
-(def +lib-version+ "0.71.0")
+(def +lib-version+ "0.71.")
 (def +version+ (str +lib-version+ "-0"))
 (def +lib-folder+ (format "semantic-ui-react-%s" +lib-version+))
 
@@ -26,7 +26,7 @@
 
 (deftask download-semantic-ui-react []
   (download :url      url
-            :checksum "8462E312FE38B411A90FC766536C10B1"))
+            :checksum "7302B4A1F73A40729B869119AC98FDAA"))
 
 (deftask package []
   (comp

--- a/semantic-ui-react/build.boot
+++ b/semantic-ui-react/build.boot
@@ -10,7 +10,7 @@
          '[clojure.java.io :as io]
          '[boot.util :refer [sh]])
 
-(def +lib-version+ "0.71.")
+(def +lib-version+ "0.71.4-0")
 (def +version+ (str +lib-version+ "-0"))
 (def +lib-folder+ (format "semantic-ui-react-%s" +lib-version+))
 

--- a/semantic-ui-react/build.boot
+++ b/semantic-ui-react/build.boot
@@ -10,7 +10,7 @@
          '[clojure.java.io :as io]
          '[boot.util :refer [sh]])
 
-(def +lib-version+ "0.71.4-0")
+(def +lib-version+ "0.71.4")
 (def +version+ (str +lib-version+ "-0"))
 (def +lib-folder+ (format "semantic-ui-react-%s" +lib-version+))
 


### PR DESCRIPTION
Bump semantic-ui-react from 0.71.0 to 0.71.4

Update:

**Extern:** The API did not change.


