### PR TITLE
Missing R in Recharts

### DIFF
--- a/recharts/build.boot
+++ b/recharts/build.boot
@@ -11,7 +11,7 @@
          '[cljsjs.boot-cljsjs.packaging :refer :all])
 
 (def +lib-version+ "0.22.4")
-(def +version+ (str +lib-version+ "-0"))
+(def +version+ (str +lib-version+ "-1"))
 
 (task-options!
  pom  {:project     'cljsjs/recharts

--- a/recharts/resources/cljsjs/recharts/common/recharts.ext.js
+++ b/recharts/resources/cljsjs/recharts/common/recharts.ext.js
@@ -9,7 +9,7 @@
  * https://unpkg.com/recharts@0.22.4/umd/Recharts.min.js
  *
  **********************************************************************/
-echarts = {
+Recharts = {
   "Area": {
     "defaultProps": {
       "activeDot": {},


### PR DESCRIPTION
This comes up as warnings in the build.  I assume it should be Recharts.  Bad copy-pasta?

Update:

**Extern:** I updated the extern by hand.