### PR TITLE
[material-ui-chip-input] Update to version 0.17.0

### DIFF
--- a/material-ui-chip-input/README.md
+++ b/material-ui-chip-input/README.md
@@ -2,7 +2,7 @@
 
 [](dependency)
 ```clojure
-[cljsjs/material-ui-chip-input "0.15.0-0"] ;; latest release
+[cljsjs/material-ui-chip-input "0.17.0-0"] ;; latest release
 ```
 [](/dependency)
 
@@ -12,7 +12,7 @@ you can require the packaged library like so:
 
 ```clojure
 (ns application.core
-  (:require cljsjs.material-ui-chip-input))
+  (:require material-ui-chip-input))
 ```
 
 [flibs]: https://github.com/clojure/clojurescript/wiki/Packaging-Foreign-Dependencies

--- a/material-ui-chip-input/build.boot
+++ b/material-ui-chip-input/build.boot
@@ -1,9 +1,10 @@
 (set-env!
   :resource-paths #{"resources"}
   :dependencies '[[cljsjs/boot-cljsjs "0.5.2"  :scope "test"]
-                  [cljsjs/material-ui "0.18.0-0"]])
+                  [cljsjs/material-ui "0.19.0-0"]
+                  [cljsjs/react "15.6.1-1"]])
 
-(def +lib-version+ "0.15.0")
+(def +lib-version+ "0.17.0")
 (def +version+ (str +lib-version+ "-0"))
 (def +lib-folder+ (format "material-ui-chip-input-%s" +lib-version+))
 
@@ -25,7 +26,7 @@
 
 (deftask download-material-ui-chip-input []
          (download :url url
-                   :checksum "a3d9f18552f65ef86bd14d03ad29a29c"
+                   :checksum "bd7bc18aa3745a078d1c538ae0580ace"
                    :unzip true))
 
 (def webpack-file-name "webpack.config.js")
@@ -61,6 +62,6 @@
      (minify :in  "cljsjs/material-ui-chip-input/development/material-ui-chip-input.inc.js"
              :out "cljsjs/material-ui-chip-input/production/material-ui-chip-input.min.inc.js")
 
-     (deps-cljs :name "cljsjs.material-ui-chip-input" :requires ["cljsjs.react" "cljsjs.material-ui"])
+     (deps-cljs :name "material-ui-chip-input" :requires ["react" "cljsjs.material-ui"])
      (pom)
      (jar)))


### PR DESCRIPTION
**Extern:** The API did not change.
