### PR TITLE
React-autosuggest updated  to v9.3.2

### DIFF
--- a/react-autosuggest/README.md
+++ b/react-autosuggest/README.md
@@ -2,7 +2,7 @@
 
 [](dependency)
 ```clojure
-[cljsjs/react-autosuggest "9.0.0-0"] ;; latest release
+[cljsjs/react-autosuggest "9.3.2-0"] ;; latest release
 ```
 [](/dependency)
 

--- a/react-autosuggest/build.boot
+++ b/react-autosuggest/build.boot
@@ -9,9 +9,9 @@
          '[boot.util :refer [sh]]
          '[clojure.string :as str])
 
-(def +lib-version+ "9.0.0")
+(def +lib-version+ "9.3.2")
 (def +version+ (str +lib-version+ "-0"))
-(def +expected-checksum+ "E014B6B59C46C415F06A4277002541D6")
+(def +expected-checksum+ "AE435FBF7457FB5D7852BD799C9F5291")
 
 (task-options!
   pom  {:project     'cljsjs/react-autosuggest

--- a/react-autosuggest/build.boot
+++ b/react-autosuggest/build.boot
@@ -32,7 +32,7 @@
         (io/copy (tmpd/file f) target))
       (let [build-dir  (str (io/file tmp (format "react-autosuggest-%s" +lib-version+)))]
         (binding [boot.util/*sh-dir* build-dir]
-          ((sh "npm" "install"))))
+          ((sh "npm" "install" "--unsafe-perm"))))
       (-> fileset (boot/add-resource tmp) boot/commit!))))
 
 
@@ -40,7 +40,7 @@
   (comp
     (download :url (str "https://github.com/moroshko/react-autosuggest/archive/v" +lib-version+ ".zip")
               :checksum +expected-checksum+
-              :unzip true) 
+              :unzip true)
     (build-autosuggest)
 
     (sift :move {#"^react-autosuggest.*[/ \\]dist[/ \\]standalone[/ \\]autosuggest.js$" "cljsjs/react-autosuggest/development/react-autosuggest.inc.js"
@@ -53,4 +53,3 @@
                           "cljsjs.react.dom"])
     (pom)
     (jar)))
-

--- a/react-autosuggest/resources/cljsjs/react-autosuggest/common/react-autosuggest.ext.js
+++ b/react-autosuggest/resources/cljsjs/react-autosuggest/common/react-autosuggest.ext.js
@@ -8,6 +8,7 @@ var Autosuggest = {
 	"renderSuggestion": {},
 	"inputProps": {},
 	"onSuggestionSelected": {},
+    "onSuggestionHighlighted": {},
 	"shouldRenderSuggestions": {},
 	"alwaysRenderSuggestions": {},
 	"focusFirstSuggestion": {},
@@ -29,6 +30,7 @@ var Autosuggest = {
 	"renderSuggestion": {},
 	"inputProps": {},
 	"onSuggestionSelected": {},
+    "onSuggestionHighlighted": {},
 	"shouldRenderSuggestions": {},
 	"alwaysRenderSuggestions": {},
 	"focusFirstSuggestion": {},
@@ -42,4 +44,3 @@ var Autosuggest = {
 	"id": {}
     }
 }
-


### PR DESCRIPTION
Commit and PR based on https://github.com/cljsjs/packages/pull/1085.

Minimal api change, https://github.com/moroshko/react-autosuggest/releases/tag/v9.3.2

**Extern:** The API did not change.