### PR TITLE
Added missing Firebase externs

### DIFF
--- a/firebase/resources/deps.cljs
+++ b/firebase/resources/deps.cljs
@@ -7,4 +7,6 @@
            "cljsjs/common/firebase-auth-externs.js"
            "cljsjs/common/firebase-server-auth-externs.js"
            "cljsjs/common/firebase-client-auth-externs.js"
+           "cljsjs/common/firebase-messaging-externs.js"
+           "cljsjs/common/firebase-error-externs.js"
            "cljsjs/common/firebase-app-externs.js"]}


### PR DESCRIPTION
The externs are taken from Firebase's externs in its repo.
Messaging specifically was missing, which is a main feature.

**Extern:** Included in Firebase distribution.