### PR TITLE
Bump semantic-ui to 2.2.13

### DIFF
--- a/semantic-ui/build.boot
+++ b/semantic-ui/build.boot
@@ -5,7 +5,7 @@
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
-(def +lib-version+ "2.2.4")
+(def +lib-version+ "2.2.13")
 (def +version+ (str +lib-version+ "-0"))
 
 (task-options!
@@ -20,7 +20,7 @@
   (comp
     (download
       :url (format "https://github.com/Semantic-Org/Semantic-UI/archive/%s.zip" +lib-version+)
-      :checksum "F62E6DE8BA291AFF9AEBB4375E1CAB8C"
+      :checksum "00B07F03AFAD84E119C6B7679D7008D6"
       :unzip true)
     (sift :move {#"^Semantic-UI-.*/dist/semantic.js$"     "cljsjs/semantic-ui/development/semantic.inc.js"
                  #"^Semantic-UI-.*/dist/semantic.min.js$" "cljsjs/semantic-ui/production/semantic.min.inc.js"


### PR DESCRIPTION
Update:

**Extern:** Not needed - was not there.