### PR TITLE
PixiJS v4.6.1

### DIFF
--- a/pixi/README.md
+++ b/pixi/README.md
@@ -2,7 +2,7 @@
 
 [](dependency)
 ```clojure
-[cljsjs/pixi "4.6.0-0"] ;; latest release
+[cljsjs/pixi "4.6.1-0"] ;; latest release
 ```
 [](/dependency)
 

--- a/pixi/build.boot
+++ b/pixi/build.boot
@@ -4,7 +4,7 @@
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
-(def +lib-version+ "4.6.0")
+(def +lib-version+ "4.6.1")
 (def +version+ (str +lib-version+ "-0"))
 
 (task-options!
@@ -18,9 +18,9 @@
 (deftask package []
   (comp
     (download :url (str "https://cdnjs.cloudflare.com/ajax/libs/pixi.js/" +lib-version+ "/pixi.min.js")
-              :checksum "732A2D55D7FA04FB81C0584B329AAEC0")
+              :checksum "E5FAEA102D9B83A33A34BBB195F78C9C")
     (download :url (str "https://cdnjs.cloudflare.com/ajax/libs/pixi.js/" +lib-version+ "/pixi.js")
-              :checksum "4B179C8BEC4AA50EF20D81D1D14BC664")
+              :checksum "F6B2DCBFA0E62DDABB75560767E582F5")
     (sift :move {#"pixi\.js$" "cljsjs/pixi/development/pixi.inc.js"
                  #"pixi\.min\.js$" "cljsjs/pixi/development/pixi.min.inc.js"})
     (sift :include #{#"^cljsjs"})


### PR DESCRIPTION
**Extern:** The API did not change.
