### PR TITLE
[react] Add react-dom-test-utils

### DIFF
--- a/react/build.boot
+++ b/react/build.boot
@@ -7,9 +7,13 @@
 (def +lib-version+ "16.2.0")
 (def +version+ (str +lib-version+ "-0"))
 
-(def npm-project {'cljsjs/react "react"
-                  'cljsjs/react-dom "react-dom"
-                  'cljsjs/react-dom-server "react-dom"})
+(defn npm-project [project]
+  (case project
+    'cljsjs/react "react"
+    ('cljsjs/react-dom
+     'cljsjs/react-dom-test-utils
+     'cljsjs/react-dom-server)
+    "react-dom"))
 
 (task-options!
  pom  {:project     'cljsjs/react
@@ -62,11 +66,20 @@
 
 (deftask package-dom []
   (package-part
-    {:extern-name "react-dom.ext.js"
-     :provides ["react-dom" "cljsjs.react.dom"]
-     :requires ["react"]
-     :global-exports '{react-dom ReactDOM}
-     :project 'cljsjs/react-dom
+   {:extern-name "react-dom.ext.js"
+    :provides ["react-dom" "cljsjs.react.dom"]
+    :requires ["react"]
+    :global-exports '{react-dom ReactDOM}
+    :project 'cljsjs/react-dom
+    :dependencies [['cljsjs/react +version+]]}))
+
+(deftask package-dom-test-utils []
+  (package-part
+    {:extern-name "react-dom-test-utils.ext.js"
+     :provides ["react-dom-test-utils" "cljsjs.react.dom"]
+     :requires ["react-dom"]
+     :global-exports '{react-dom-test-utils ReactTestUtils}
+     :project 'cljsjs/react-dom-test-utils
      :dependencies [['cljsjs/react +version+]]}))
 
 (deftask package-dom-server []
@@ -83,5 +96,6 @@
   (comp
     (package-react)
     (package-dom)
+    (package-dom-test-utils)
     (package-dom-server)
     (validate)))


### PR DESCRIPTION
**Extern:** Not yet provided.

In React 16 the TestUtils addon was moved not to its own package but to ReactDOM, but built separately as `react-dom-test-utils.*.js`. This adds it as a fourth package within `react`.

I have a feeling there's a great way to generate the externs for this, but I don't know it. What's the best way to do it?