### PR TITLE
auth0-lock: update to 10.24.1

### DIFF
--- a/auth0-lock/README.md
+++ b/auth0-lock/README.md
@@ -2,7 +2,7 @@
 
 [](dependency)
 ```clojure
-[cljsjs/auth0-lock "10.21.1-0"] ;; latest release
+[cljsjs/auth0-lock "10.24.1-0"] ;; latest release
 ```
 [](/dependency)
 

--- a/auth0-lock/boot-cljsjs-checksums.edn
+++ b/auth0-lock/boot-cljsjs-checksums.edn
@@ -1,0 +1,4 @@
+{"cljsjs/auth0-lock/development/lock.inc.js"
+ "D7A0EB60667B2ED0F40CA5D8B4702D15",
+ "cljsjs/auth0-lock/production/lock.min.inc.js"
+ "92B23471860236AA18F258EC44BC65C9"}

--- a/auth0-lock/build.boot
+++ b/auth0-lock/build.boot
@@ -4,7 +4,7 @@
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
-(def +lib-version+ "10.21.1")
+(def +lib-version+ "10.24.1")
 (def +version+ (str +lib-version+ "-0"))
 
 (task-options!
@@ -24,4 +24,5 @@
     (sift :include #{#"^cljsjs"})
     (deps-cljs :name "cljsjs.auth0-lock")
     (pom)
-    (jar)))
+    (jar)
+    (validate-checksums)))


### PR DESCRIPTION
Also added checksums 

Update:

**Extern:** The API did not change.
