### PR TITLE
[accounting] Update externs

### DIFF
--- a/accounting/README.md
+++ b/accounting/README.md
@@ -2,7 +2,7 @@
 
 [](dependency)
 ```clojure
-[cljsjs/accounting "0.4.1-0"] ;; latest release
+[cljsjs/accounting "0.4.1-1"] ;; latest release
 ```
 [](/dependency)
 

--- a/accounting/build.boot
+++ b/accounting/build.boot
@@ -6,7 +6,7 @@
          '[boot.core :as boot])
 
 (def +lib-version+ "0.4.1")
-(def +version+ (str +lib-version+ "-0"))
+(def +version+ (str +lib-version+ "-1"))
 
 (task-options!
  pom  {:project     'cljsjs/accounting

--- a/accounting/resources/cljsjs/accounting/common/accounting.ext.js
+++ b/accounting/resources/cljsjs/accounting/common/accounting.ext.js
@@ -1,12 +1,7 @@
-var accounting = {}
-
-accounting.formatMoney = function (number, symbol, precision, thousand, decimal, format) {}
-
-accounting.formatColumn = function(list, symbol, precision, thousand, decimal, format) {}
-
-accounting.formatNumber = function(number, precision, thousand, decimal) {}
-
-accounting.toFixed = function(value, precision) {}
-
-accounting.unformat = function(value, decimal) {}
-
+var accounting = {
+  "formatMoney": function () {},
+  "formatColumn": function() {},
+  "formatNumber": function() {},
+  "toFixed": function() {},
+  "unformat": function() {}
+}


### PR DESCRIPTION
The existing externs for accounting would generate several warnings similar to the following when building a project with advanced optimizations enabled. This PR updates the externs to fix this issue.

```
WARNING - name accounting is not defined in the externs.
accounting.toFixed = function(value, precision) {}
^^^^^^^^^^
```
