### PR TITLE
Added react-router-dom@4.2.2

### DIFF
--- a/react-router-dom/README.md
+++ b/react-router-dom/README.md
@@ -1,0 +1,20 @@
+# cljsjs/react-router-dom
+
+[](dependency)
+```clojure
+[cljsjs/react-router-dom "4.2.2-0"] ;; latest release
+```
+[](/dependency)
+
+This jar comes with `deps.cljs` as used by the [Foreign Libs][flibs] feature
+of the ClojureScript compiler. After adding the above dependency to your project
+you can require the packaged library like so:
+
+```clojure
+(ns application.core
+  (:require cljsjs.react-router-dom))
+```
+
+The above will make `js/ReactRouterDOM` available
+
+[flibs]: https://clojurescript.org/reference/packaging-foreign-deps

--- a/react-router-dom/build.boot
+++ b/react-router-dom/build.boot
@@ -1,0 +1,33 @@
+(set-env!
+  :resource-paths #{"resources"}
+  :dependencies '[[cljsjs/boot-cljsjs "0.9.0" :scope "test"]
+                  [cljsjs/react "16.2.0-0"]])
+
+(require '[cljsjs.boot-cljsjs.packaging :refer :all])
+
+(def +lib-version+ "4.2.2")
+(def +version+ (str +lib-version+ "-0"))
+
+(task-options!
+  pom {:project 'cljsjs/react-router-dom
+       :version +version+
+       :description "Declarative routing for React"
+       :url "https://github.com/ReactTraining/react-router-dom"
+       :scm {:url "https://github.com/cljsjs/packages"}
+       :license {"MIT" "http://opensource.org/licenses/MIT"}})
+
+(deftask package []
+         (comp
+           (download :url (str "https://unpkg.com/react-router-dom@" +lib-version+ "/umd/react-router-dom.js"))
+           (download :url (str "https://unpkg.com/react-router-dom@" +lib-version+ "/umd/react-router-dom.min.js"))
+
+           (sift :move {#"react-router-dom.js"
+                        "cljsjs/react-router/development/react-router-dom.inc.js"
+                        #"react-router-dom.min.js"
+                        "cljsjs/react-router/production/react-router-dom.min.inc.js"})
+           (sift :include #{#"^cljsjs"})
+           (deps-cljs :name "cljsjs.react-router-dom"
+                      :requires ["cljsjs.react"])
+           (pom)
+           (jar)
+           (validate-checksums)))

--- a/react-router-dom/resources/cljsjs/react-router-dom/common/react-router-dom.ext.js
+++ b/react-router-dom/resources/cljsjs/react-router-dom/common/react-router-dom.ext.js
@@ -1,0 +1,16 @@
+var ReactRouterDOM = {
+    BrowserRouter: function () {},
+    HashRouter: function () {},
+    Link: function () {},
+    MemoryRouter: function () {},
+    NavLink: function () {},
+    Prompt: function () {},
+    Redirect: function () {},
+    Route: function () {},
+    Router: function () {},
+    StaticRouter: function () {},
+    Switch: function () {},
+    matchPath: function () {},
+    withRouter: function () {},
+    __esModule: true
+};


### PR DESCRIPTION
This PR adds `react-router-dom`. This is not to be confused with the `react-router` package which is an old version and published to `npm` under a different name.