### PR TITLE
Auth0 bump to 9.2.1

### DIFF
--- a/auth0/README.md
+++ b/auth0/README.md
@@ -2,7 +2,7 @@
 
 [](dependency)
 ```clojure
-[cljsjs/auth0 "8.12.1-0"] ;; latest release
+[cljsjs/auth0 "9.2.1-0"] ;; latest release
 ```
 [](/dependency)
 

--- a/auth0/boot-cljsjs-checksums.edn
+++ b/auth0/boot-cljsjs-checksums.edn
@@ -1,4 +1,4 @@
 {"cljsjs/auth0/development/auth0.inc.js"
- "100c4fc73d5b12c02c6a5c4eb564cafe"
+ "100C4FC73D5B12C02C6A5C4EB564CAFE",
  "cljsjs/auth0/production/auth0.min.inc.js"
- "86146642cfd576bb97e5f89d2292a084"}
+ "86146642CFD576BB97E5F89D2292A084"}

--- a/auth0/boot-cljsjs-checksums.edn
+++ b/auth0/boot-cljsjs-checksums.edn
@@ -1,4 +1,4 @@
 {"cljsjs/auth0/development/auth0.inc.js"
- "C654CAE40C6ED351109EB23837B34450",
+ "100c4fc73d5b12c02c6a5c4eb564cafe"
  "cljsjs/auth0/production/auth0.min.inc.js"
- "824E147E81A91EDF84A41F56A0F69B47"}
+ "86146642cfd576bb97e5f89d2292a084"}

--- a/auth0/build.boot
+++ b/auth0/build.boot
@@ -4,7 +4,7 @@
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
-(def +lib-version+ "8.12.1")
+(def +lib-version+ "9.2.1")
 (def +version+ (str +lib-version+ "-0"))
 
 (task-options!

--- a/auth0/resources/cljsjs/auth0/common/auth0.ext.js
+++ b/auth0/resources/cljsjs/auth0/common/auth0.ext.js
@@ -30,6 +30,7 @@ auth0.WebAuth.prototype = {
   "changePassword": function () {},
   "checkSession": function () {},
   "crossOriginAuthenticationCallback": function () {},
+  "crossOriginVerification": function () {},
   "login": function () {},
   "logout": function () {},
   "parseHash": function () {},


### PR DESCRIPTION
Bumping Auth0 to 9.2.1 (instead of 9.2.2) because Auth0 Lock 11.2.2 depends on this specific version.

Externs auto-generated.