### PR TITLE
Updated quill to 1.3.5; added checksums

### DIFF
--- a/quill/boot-cljsjs-checksums.edn
+++ b/quill/boot-cljsjs-checksums.edn
@@ -1,0 +1,4 @@
+{"cljsjs/quill/quill.inc.js" "7D2C0507644124A15ABFA868F6DC050C"
+ "cljsjs/quill/quill.min.inc.js" "8D9593A6CF1CEB87B98DDAC636C3E572"
+ "cljsjs/quill/quill.core.css" "2A7D7377AB26EBC584B122333A848B97"
+ "cljsjs/quill/quill.snow.css" "B0AED58B7969A27410AB62A78BD2EFEE"}

--- a/quill/boot-cljsjs-checksums.edn
+++ b/quill/boot-cljsjs-checksums.edn
@@ -1,4 +1,2 @@
-{"cljsjs/quill/quill.inc.js" "7D2C0507644124A15ABFA868F6DC050C"
- "cljsjs/quill/quill.min.inc.js" "8D9593A6CF1CEB87B98DDAC636C3E572"
- "cljsjs/quill/quill.core.css" "2A7D7377AB26EBC584B122333A848B97"
- "cljsjs/quill/quill.snow.css" "B0AED58B7969A27410AB62A78BD2EFEE"}
+{"cljsjs/quill/quill.inc.js" "7D2C0507644124A15ABFA868F6DC050C",
+ "cljsjs/quill/quill.min.inc.js" "8D9593A6CF1CEB87B98DDAC636C3E572"}

--- a/quill/build.boot
+++ b/quill/build.boot
@@ -20,10 +20,10 @@
                      :decompress true
                      :archive-format "tar"
                      :compression-format "gz")
-           (sift :move {#".*quill\.js"        "cljsjs/quill/quill.inc.js"
-                        #".*quill\.min\.js"   "cljsjs/quill/quill.min.inc.js"
+           (sift :move {#".*quill\.js" "cljsjs/quill/quill.inc.js"
+                        #".*quill\.min\.js" "cljsjs/quill/quill.min.inc.js"
                         #".*quill\.core\.css" "cljsjs/quill/quill.core.css"
-                        #".*dist/quill\.snow\.css" "cljsjs/quill/quill.snow.css"})
+                        #".*quill\.snow\.css" "cljsjs/quill/quill.snow.css"})
            (sift :include #{#"^cljsjs"})
            (deps-cljs :name "cljsjs.quill")
            (validate-checksums)

--- a/quill/build.boot
+++ b/quill/build.boot
@@ -4,21 +4,19 @@
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
-(def +lib-version+ "1.2.5") ;; released at May 28, 2017
-(def +version+ (str +lib-version+ "-4"))
+(def +lib-version+ "1.3.5")
+(def +version+ (str +lib-version+ "-0"))
 
 (task-options!
   pom {:project     'cljsjs/quill
        :version     +version+
-       :description "Quill is a free, open source WYSIWYG editor built for the modern web."
+       :description "QuillJS is a modern rich text editor built for compatibility and extensibility."
        :url         "http://quilljs.com/"
        :license     {"BSD 3-Clause" "http://opensource.org/licenses/BSD-3-Clause"}})
 
 (deftask package []
          (comp
-           (download :url
-                     (format "https://github.com/quilljs/quill/releases/download/v%s/quill.tar.gz" +lib-version+)
-                     :checksum "CC0A9A7A866B40A63E0D3418B57A8F70"
+           (download :url (format "https://github.com/quilljs/quill/releases/download/v%s/quill.tar.gz" +lib-version+)
                      :decompress true
                      :archive-format "tar"
                      :compression-format "gz")
@@ -28,5 +26,6 @@
                         #".*dist/quill\.snow\.css" "cljsjs/quill/quill.snow.css"})
            (sift :include #{#"^cljsjs"})
            (deps-cljs :name "cljsjs.quill")
+           (validate-checksums)
            (pom)
            (jar)))

--- a/quill/resources/cljsjs/quill/common/quill.ext.js
+++ b/quill/resources/cljsjs/quill/common/quill.ext.js
@@ -19,6 +19,7 @@ var Quill = {
   "removeFormat": function() {},
   "text-change": function() {},
   "selection-change": function() {},
+  "editor-change": function() {},
   "off": function() {},
   "on": function() {},
   "once": function() {},


### PR DESCRIPTION
* Added `boot-cljsjs-checksums.edn` for quill
* Updated quill to 1.3.5
* Updated the description according to the official documentation
* Updated the API