### PR TITLE
[react-stripe-elements] include dependencies for cljsjs.react and clj…

### DIFF
--- a/react-stripe-elements/README.md
+++ b/react-stripe-elements/README.md
@@ -4,7 +4,7 @@ https://github.com/stripe/react-stripe-elements
 
 [](dependency)
 ```clojure
-[cljsjs/react-stripe-elements "1.4.1-0"] ;; latest release
+[cljsjs/react-stripe-elements "1.4.1-1"] ;; latest release
 ```
 [](/dependency)
 
@@ -16,3 +16,15 @@ you can require the packaged library like so:
 (ns application.core
   (:require cljsjs.react-stripe-elements))
 ```
+
+The Stripe.js API will still need to be provided via:
+
+<script src="https://js.stripe.com/v3/"></script>
+
+From https://stripe.com/docs/stripe-js/reference
+
+"To best leverage Stripe’s advanced fraud functionality, include this script on every page of your site, not just the checkout page. This allows Stripe to detect anomalous behavior that may be indicative of fraud as customers browse your website."
+
+For an example implementation of react-stripe-elements using Reagent see:
+
+https://github.com/jborden/reagent-stripe-elements-demo

--- a/react-stripe-elements/build.boot
+++ b/react-stripe-elements/build.boot
@@ -1,11 +1,13 @@
 (set-env!
-  :resource-paths #{"resources"}
-  :dependencies '[[cljsjs/boot-cljsjs "0.9.0" :scope "test"]])
+ :resource-paths #{"resources"}
+ :dependencies '[[cljsjs/boot-cljsjs "0.9.0" :scope "test"]
+                 [cljsjs/stripe "2.0-0"]
+                 [cljsjs/react "15.6.2-4"]])
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
 (def +lib-version+ "1.4.1")
-(def +version+ (str +lib-version+ "-0"))
+(def +version+ (str +lib-version+ "-1"))
 
 (task-options!
  pom  {:project     'cljsjs/react-stripe-elements
@@ -21,7 +23,8 @@
              :target "cljsjs/react-stripe-elements/development/react-stripe-elements.inc.js")
    (download :url (format "https://unpkg.com/react-stripe-elements@%s/dist/react-stripe-elements.min.js" +lib-version+)
              :target "cljsjs/react-stripe-elements/production/react-stripe-elements.min.inc.js")
-   (deps-cljs :name "cljsjs.react-stripe-elements")
+   (deps-cljs :name "cljsjs.react-stripe-elements"
+              :requires ["cljsjs.react"])
    (pom)
    (jar)
    (validate-checksums)))


### PR DESCRIPTION
I've included some additional dependencies on cljsjs.react and cljsjs.stripe that I missed when I initially submitted this library. 

The cljsjs.react dependency is an older version because the newer one breaks Reagent.  The call to reagent.core/adapt-react-class depends on a fn that is no longer available in the latest version of React. adapt-react-class is needed to make use of the react-stripe-elements. 

I've also included additional text in the README.md about usage of this library and an example project that I created to demonstrate the use of react-stripe-elements with Reagent. 
