### PR TITLE
[iota-mam] Add iotaledger/mam.client.js

### DIFF
--- a/iota-mam/README.md
+++ b/iota-mam/README.md
@@ -1,0 +1,21 @@
+# cljsjs/iota
+
+[](dependency)
+```clojure
+[cljsjs/iota-mam "0.0.1-0"] ;; latest release
+```
+[](/dependency)
+
+This jar comes with `deps.cljs` as used by the [Foreign Libs][flibs] feature of the ClojureScript compiler. After adding the above dependency to your project you can require the packaged library like so:
+
+```clojure
+(ns application.core
+  (:require cljsjs.iota-mam))
+```
+or
+```clojure
+(ns application.core
+  (:require cljsjs.iota-mam-light))
+```
+
+[flibs]: https://clojurescript.org/reference/packaging-foreign-deps

--- a/iota-mam/build.boot
+++ b/iota-mam/build.boot
@@ -1,0 +1,27 @@
+(set-env!
+ :resource-paths #{"resources"}
+ :dependencies '[[cljsjs/boot-cljsjs "0.9.0" :scope "test"]])
+
+(require '[cljsjs.boot-cljsjs.packaging :refer :all])
+
+(def +lib-version+ "0.0.1")
+(def +version+ (str +lib-version+ "-0"))
+
+(task-options!
+ pom {:project     'cljsjs/iota-mam
+      :version     +version+
+      :description "IOTA MAM Javascript Library"
+      :url         "https://dev.iota.org"
+      :scm         {:url "https://github.com/iotaledger/mam.client.js"}
+      :license     {"MIT License" "https://opensource.org/licenses/MIT"}})
+
+(deftask package []
+  (comp
+   (download :url (str "https://github.com/iotaledger/mam.client.js/archive/master.zip")
+             :unzip true)
+   (sift :move {#"^mam.client.js-master/lib/mam.web.js"                    "cljsjs/iota/development/mam.web.inc.js"
+                #"^mam.client.js-master/lib/iota-bindings-emscripten.wasm" "cljsjs/iota/development/iota-bindings-emscripten.wasm"})
+   (sift :include #{#"^cljsjs" #"^deps.cljs"})
+   (deps-cljs :name "cljsjs.iota-mam")
+   (pom)
+   (jar)))


### PR DESCRIPTION
Adds [IOTA ledger's mam.client.js](https://github.com/iotaledger/mam.client.js). There is no official release of mam.client.js, so it uses the master.zip. Is this okay for now?