### PR TITLE
[iota-mam] Add installation instructions

### DIFF
--- a/iota-mam/README.md
+++ b/iota-mam/README.md
@@ -6,6 +6,8 @@
 ```
 [](/dependency)
 
+NOTE: at the moment it is necessary to serve the file [iota-bindings-emscripten.wasm](https://raw.githubusercontent.com/iotaledger/mam.client.js/master/lib/iota-bindings-emscripten.wasm) at the root of the appication when using this library (e.g., place it in `resources/public`) of your application.
+
 This jar comes with `deps.cljs` as used by the [Foreign Libs][flibs] feature of the ClojureScript compiler. After adding the above dependency to your project you can require the packaged library like so:
 
 ```clojure


### PR DESCRIPTION
Description of a necessary step for the require to work.

I don't know how to properly compile the wasm into the JavaScript file. The [`mam.node.js`](https://raw.githubusercontent.com/iotaledger/mam.client.js/master/lib/mam.node.js) file doesn't succeed in proving a `js/Mam` object.