### PR TITLE
[react-transition-group] download minified source to correct target

### DIFF
--- a/react-transition-group/build.boot
+++ b/react-transition-group/build.boot
@@ -7,7 +7,7 @@
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
 (def +lib-version+ "2.2.1")
-(def +version+ (str +lib-version+ "-0"))
+(def +version+ (str +lib-version+ "-1"))
 
 (task-options!
  pom  {:project     'cljsjs/react-transition-group
@@ -19,9 +19,9 @@
 
 (deftask package []
   (comp
-   (download :url (format "https://unpkg.com/react-transition-group@%s/dist/react-transition-group.js" +lib-version+)
-             :target "cljsjs/react-transition-group/production/react-transition-group.min.inc.js")
    (download :url (format "https://unpkg.com/react-transition-group@%s/dist/react-transition-group.min.js" +lib-version+)
+             :target "cljsjs/react-transition-group/production/react-transition-group.min.inc.js")
+   (download :url (format "https://unpkg.com/react-transition-group@%s/dist/react-transition-group.js" +lib-version+)
              :target "cljsjs/react-transition-group/development/react-transition-group.inc.js")
    (deps-cljs :provides ["react-transition-group" "react-transition-group/TransitionGroup" "react-transition-group/CSSTransition" "react-transition-group/Transition"
                          "cljsjs.react-transition-group"]


### PR DESCRIPTION
This package was switching the minified and unminified source, with hilarious results
See #1501

<!--
PR Checklist

Have you read either:
https://github.com/cljsjs/packages/wiki/Creating-Packages
https://github.com/cljsjs/packages/wiki/Updating-packages

Did you follow contribution guidelines:
https://github.com/cljsjs/packages/blob/master/CONTRIBUTING.md

Did you remember to run package script locally and commit
boot-cljsjs-checksum.edn file changes?

boot package install
-->
