### PR TITLE
[slate-html-serializer] Update slate-html-serializer to 0.6.1-0

### DIFF
--- a/slate-html-serializer/README.md
+++ b/slate-html-serializer/README.md
@@ -2,7 +2,7 @@
 
 [](dependency)
 ```clojure
-[cljsjs/slate-html-serializer "0.4.11-2"] ;; latest release
+[cljsjs/slate-html-serializer "0.6.1-0"] ;; latest release
 ```
 [](/dependency)
 

--- a/slate-html-serializer/build.boot
+++ b/slate-html-serializer/build.boot
@@ -1,13 +1,13 @@
-(def +lib-version+ "0.4.11")
-(def +version+ (str +lib-version+ "-2"))
+(def +lib-version+ "0.6.1")
+(def +version+ (str +lib-version+ "-0"))
 
 (set-env!
  :resource-paths #{"resources"}
- :dependencies '[[cljsjs/boot-cljsjs "0.8.2" :scope "test"]
-                 [cljsjs/react            "15.6.2-2"]
-                 [cljsjs/react-dom        "15.6.2-2"]
-                 [cljsjs/react-dom-server "15.6.2-2"]
-                 [cljsjs/slate            "0.31.3-0"]
+ :dependencies '[[cljsjs/boot-cljsjs "0.10.0" :scope "test"]
+                 [cljsjs/react            "16.3.0-0"]
+                 [cljsjs/react-dom        "16.3.0-0"]
+                 [cljsjs/react-dom-server "16.3.0-0"]
+                 [cljsjs/slate            "0.33.4-0"]
                  [cljsjs/immutable        "3.8.1-0"]])
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
@@ -23,9 +23,9 @@
 (deftask package  []
   (comp
    (download :url (str "https://unpkg.com/slate-html-serializer@" +lib-version+  "/dist/slate-html-serializer.js")
-             :checksum "2eb073a3a19a4ae06f7652215e9e1958")
+             :checksum "98502e9a2e6a31b6908572e4b213ea8a")
    (download :url (str "https://unpkg.com/slate-html-serializer@" +lib-version+  "/dist/slate-html-serializer.min.js")
-             :checksum "04d31f493951da65bbd34e08b968e6d0")
+             :checksum "e201771bda3d0b7c0ebcd40f49a10869")
    (sift :move {#"^slate-html-serializer.js$"
                 "cljsjs/slate-html-serializer/development/slate-html-serializer.inc.js"
                 #"^slate-html-serializer.min.js"

--- a/slate-html-serializer/resources/cljsjs/common/slate-html-serializer.ext.js
+++ b/slate-html-serializer/resources/cljsjs/common/slate-html-serializer.ext.js
@@ -1,14 +1,7 @@
 var SlateHtmlSerializer = {
     "Html": {
         "deserialize": function() {},
-        "deserializeElements": function() {},
-        "deserializeElement": function() {},
-        "deserializeMark": function() {},
         "serialize": function() {},
-        "serializeNode": function() {},
-        "serializeLeaf": function() {},
-        "serializeString": function() {},
-        "cruftNewline": function() {},
         "parseHtml": function() {}
     }
 };


### PR DESCRIPTION
This PR will fail until https://github.com/cljsjs/packages/pull/1542 is merged.