### PR TITLE
[react-sortable-hoc] Add cljsjs/react-sortable-hoc "0.5.0-0"

### DIFF
--- a/react-sortable-hoc/README.md
+++ b/react-sortable-hoc/README.md
@@ -1,0 +1,18 @@
+# cljsjs/react-sortable-hoc
+
+[](dependency)
+```clojure
+[cljsjs/react-sortable-hoc "0.5.0-0"]
+```
+[](/dependency)
+
+This jar comes with `deps.cljs` as used by the [Foreign Libs][flibs] feature
+of the ClojureScript compiler. After adding the above dependency to your project
+you can require the packaged library like so:
+
+```clojure
+(ns application.core
+  (:require cljsjs.react-sortable-hoc))
+```
+
+[flibs]: https://clojurescript.org/reference/packaging-foreign-deps

--- a/react-sortable-hoc/boot-cljsjs-checksums.edn
+++ b/react-sortable-hoc/boot-cljsjs-checksums.edn
@@ -1,0 +1,4 @@
+{"cljsjs/react-sortable-hoc/development/react-sortable-hoc.inc.js"
+ "771A045C73C0B1EB6228332B18650C97",
+ "cljsjs/react-sortable-hoc/production/react-sortable-hoc.min.inc.js"
+ "71BA2D45818CAF92E98E5CAE48A22E37"}

--- a/react-sortable-hoc/build.boot
+++ b/react-sortable-hoc/build.boot
@@ -1,0 +1,32 @@
+(set-env!
+  :resource-paths #{"resources"}
+  :dependencies '[[cljsjs/boot-cljsjs "0.9.0"  :scope "test"]
+                  [cljsjs/react "15.2.1-0"]
+                  [cljsjs/react-dom "15.2.1-0"]])
+
+(require '[cljsjs.boot-cljsjs.packaging :refer :all])
+
+(def +lib-version+ "0.5.0")
+(def +version+ (str +lib-version+ "-0"))
+
+(task-options!
+ pom  {:project     'cljsjs/react-sortable-hoc
+       :version     +version+
+       :description "A set of higher-order components to turn any list into an animated, touch-friendly, sortable list."
+       :url         "http://clauderic.github.io/react-sortable-hoc/"
+       :scm         {:url "https://github.com/clauderic/react-sortable-hoc"}
+       :license     {"MIT" "http://opensource.org/licenses/MIT"}})
+
+(deftask package []
+  (comp
+   (download :url (format "https://unpkg.com/react-sortable-hoc@%s/dist/umd/react-sortable-hoc.js" +lib-version+)
+             :target "cljsjs/react-sortable-hoc/development/react-sortable-hoc.inc.js")
+   (download :url (format "https://unpkg.com/react-sortable-hoc@%s/dist/umd/react-sortable-hoc.min.js" +lib-version+)
+             :target "cljsjs/react-sortable-hoc/production/react-sortable-hoc.min.inc.js")
+
+   (deps-cljs :name "cljsjs.react-sortable-hoc"
+              :requires ["cljsjs.react"
+                         "cljsjs.react.dom"])
+   (pom)
+   (jar)
+   (validate-checksums)))

--- a/react-sortable-hoc/resources/cljsjs/react-sortable-hoc/common/react-sortable-hoc.ext.js
+++ b/react-sortable-hoc/resources/cljsjs/react-sortable-hoc/common/react-sortable-hoc.ext.js
@@ -1,0 +1,5 @@
+var SortableHOC = {};
+
+SortableHOC.SortableElement = function() {};
+
+SortableHOC.SortableContainer = function() {};


### PR DESCRIPTION
Adds the React Sortable (HOC) cljsjs package