### PR TITLE
[react-autosize-textarea] Upgrade react-autosize-textarea to 3.0.2

### DIFF
--- a/react-autosize-textarea/README.md
+++ b/react-autosize-textarea/README.md
@@ -2,7 +2,7 @@
 
 [](dependency)
 ```clojure
-[cljsjs/react-autosize-textarea "0.4.8-0"] ;; latest release
+[cljsjs/react-autosize-textarea "3.0.2-0"] ;; latest release
 ```
 [](/dependency)
 

--- a/react-autosize-textarea/boot-cljsjs-checksums.edn
+++ b/react-autosize-textarea/boot-cljsjs-checksums.edn
@@ -1,0 +1,4 @@
+{"cljsjs/react-autosize-textarea/development/react-autosize-textarea.inc.js"
+ "A142242833E45D6B7DFC8B02851F05D7",
+ "cljsjs/react-autosize-textarea/production/react-autosize-textarea.min.inc.js"
+ "00E622037EAFAC03A17D19C5A20C8795"}

--- a/react-autosize-textarea/build.boot
+++ b/react-autosize-textarea/build.boot
@@ -1,26 +1,25 @@
 (set-env!
-  :resource-paths #{"resources"}
-  :dependencies '[[cljsjs/boot-cljsjs "0.9.0"  :scope "test"]
-                  [cljsjs/react "15.3.1-0"]])
+ :resource-paths #{"resources"}
+ :dependencies '[[cljsjs/boot-cljsjs "0.10.0" :scope "test"]
+                 [cljsjs/react "16.3.0-0"]
+                 [cljsjs/react-dom "16.3.0-0"]])
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
-(def +lib-version+ "0.4.8")
+(def +lib-version+ "3.0.2")
 (def +version+ (str +lib-version+ "-0"))
 
 (task-options!
  pom  {:project     'cljsjs/react-autosize-textarea
        :version     +version+
-       :description "A textarea perfectly compatible with ReactJS default one
-                     which auto resizes its height based on user input."
+       :description "A light replacement for built-in <textarea /> component which automatically adjusts its height to match the content."
        :url         "https://github.com/buildo/react-autosize-textarea/"
        :scm         {:url "https://github.com/cljsjs/packages"}
        :license     {"MIT" "http://opensource.org/licenses/MIT"}})
 
 (require '[boot.core :as c]
          '[boot.util :as util]
-         '[clojure.java.io :as io]
-         '[clojure.string :as string])
+         '[clojure.java.io :as io])
 
 (deftask build []
   (let [tmp          (c/tmp-dir!)
@@ -31,18 +30,14 @@
               :let [target (io/file tmp (c/tmp-path f))]]
         (io/make-parents target)
         (io/copy (c/tmp-file f) target))
-
       (io/make-parents (io/file tmp +lib-folder+ "dist"))
-
       (io/copy
        (c/tmp-file (first (c/by-name [webpack-cfg] (c/input-files fileset))))
        (io/file tmp +lib-folder+ webpack-cfg))
-
       (binding [util/*sh-dir* (str (io/file tmp +lib-folder+))]
         ((sh "npm" "install" "--ignore-scripts"))
-        ((sh "npm" "install" "--save-dev" "webpack@2.2.1"))
+        ((sh "npm" "install" "--save-dev" "typescript@2.7.2 ts-loader@4.1.0 webpack-cli@4.4.1"))
         ((sh "./node_modules/.bin/webpack" "--config" "webpack.config.dist.js")))
-
       (-> fileset
           (c/add-resource (io/file tmp +lib-folder+ "dist"))
           c/commit!))))
@@ -50,19 +45,16 @@
 (deftask package []
   (comp
    (download :url (str "https://github.com/buildo/react-autosize-textarea/archive/v" +lib-version+ ".zip")
-             :checksum "4302387B4BEDF9109B868BC642F39FB2"
              :unzip true)
    (build)
-
    (sift :move {#"^react-autosize-textarea\.js$"
                 "cljsjs/react-autosize-textarea/development/react-autosize-textarea.inc.js"})
-
    (minify :in "cljsjs/react-autosize-textarea/development/react-autosize-textarea.inc.js"
            :out "cljsjs/react-autosize-textarea/production/react-autosize-textarea.min.inc.js")
-
    (sift :include #{#"^cljsjs"})
-
    (deps-cljs :name "cljsjs.react-autosize-textarea"
-              :requires ["cljsjs.react"])
+              :requires ["cljsjs.react"
+                         "cljsjs.react-dom"])
    (pom)
-   (jar)))
+   (jar)
+   (validate-checksums)))

--- a/react-autosize-textarea/resources/cljsjs/react-autosize-textarea/common/react-autosize-textarea.ext.js
+++ b/react-autosize-textarea/resources/cljsjs/react-autosize-textarea/common/react-autosize-textarea.ext.js
@@ -1,16 +1,20 @@
-var TextareaAutosize = {
-  "displayName": {},
-  "propTypes": {
+var TextareaAutosize = function () {};
+
+TextareaAutosize.prototype = {
+    constructor: function () {},
+    componentDidMount: function () {},
+    componentWillUnmount: function () {},
+    render: function () {},
+    componentDidUpdate: function () {}
+};
+
+TextareaAutosize.defaultProps = {
+    "rows": {}
+};
+
+TextareaAutosize.propTypes = {
     "rows": {},
     "maxRows": {},
     "onResize": function (){},
     "innerRef": function (){}
-  },
-  "defaultProps": {
-    "rows" : {}
-  },
-  "forceUpdate": function (){},
-  "isReactComponent": function (){},
-  "onChange": function (){},
-  "setState": function (){}
 };

--- a/react-autosize-textarea/resources/webpack.config.dist.js
+++ b/react-autosize-textarea/resources/webpack.config.dist.js
@@ -1,30 +1,26 @@
 var webpack = require('webpack');
 
 module.exports = {
-  entry: './src/index.js',
-
-  module: {
-    loaders: [
-      {
-        test: /\.jsx?$/,
-        loader: 'babel-loader',
-        exclude: /node_modules/
-      },
-    ]
-  },
-
-  externals: {
-    'react': 'React',
-    'react-dom': 'ReactDOM',
-  },
-
-  output: {
-    filename: 'dist/react-autosize-textarea.js',
-    libraryTarget: 'umd',
-    library: 'TextareaAutosize'
-  },
-
-  resolve: {
-    extensions: ['.jsx', '.js']
-  }
+    entry: './src/index.ts',
+    module: {
+        loaders: [
+            {
+                test: /\.tsx?$/,
+                loader: 'ts-loader',
+                exclude: /node_modules/
+            },
+        ]
+    },
+    externals: {
+        'react': 'React',
+        'react-dom': 'ReactDOM',
+    },
+    output: {
+        filename: 'dist/react-autosize-textarea.js',
+        libraryTarget: 'umd',
+        library: 'TextareaAutosize'
+    },
+    resolve: {
+        extensions: ['.tsx', '.ts', '.js']
+    }
 };


### PR DESCRIPTION
Upgraded to latest version.

Cleaned up `build.boot` to get validate checksums properly, use webpack-cli, adjust for source being in typescript.

@deraen Only question I have - The webpack process bundles react/react-dom into the built JS so let me know if we still need to explicitly indicate `cljsjs.react` and `cljsjs.react-dom`.