### PR TITLE
[react-color] Upgrade react-color to 2.13.8, Moved to new boot-cljsjs

### DIFF
--- a/react-color/README.md
+++ b/react-color/README.md
@@ -2,7 +2,7 @@
 
 [](dependency)
 ```clojure
-[cljsjs/react-color "2.13.1-0"] ;; latest release
+[cljsjs/react-color "2.13.8-0"] ;; latest release
 ```
 [](/dependency)
 
@@ -40,7 +40,7 @@ The following is an example of providing factory functions for each of the color
 (def slider-picker (js/React.createFactory js/ReactColor.SliderPicker))
 (def swatches-picker (js/React.createFactory js/ReactColor.SwatchesPicker))
 (def twitter-picker (js/React.createFactory js/ReactColor.TwitterPicker))
-(def color-wrap-picker (js/React.createFactory js/ReactColor.ColorWrapPicker))
+(def custom-picker (js/React.createFactory js/ReactColor.CustomPicker))
 
 ```
 

--- a/react-color/boot-cljsjs-checksums.edn
+++ b/react-color/boot-cljsjs-checksums.edn
@@ -1,0 +1,4 @@
+{"cljsjs/react-color/development/react-color.inc.js"
+ "B511D50A74450F3ACC8B383D2810EA65",
+ "cljsjs/react-color/production/react-color.min.inc.js"
+ "A586E07DA253EBF3747645B2116D8321"}

--- a/react-color/build.boot
+++ b/react-color/build.boot
@@ -1,9 +1,9 @@
 (set-env!
   :resource-paths #{"resources"}
-  :dependencies '[[cljsjs/boot-cljsjs "0.9.0"  :scope "test"]
+  :dependencies '[[cljsjs/boot-cljsjs "0.10.0"  :scope "test"]
                   [cljsjs/react "15.4.2-2"]
                   [cljsjs/lodash "4.11.2-0"]
-                  [cljsjs/tinycolor "1.3.0-0"]
+                  [cljsjs/tinycolor "1.4.1-0"]
                   [cljsjs/proptypes "0.14.3-0"]
                   [cljsjs/material-colors "1.2.5-0"]
                   [cljsjs/reactcss "1.2.0-0"]])
@@ -14,7 +14,7 @@
          '[clojure.java.io :as io]
          '[boot.util :refer [sh]])
 
-(def +lib-version+ "2.13.1")
+(def +lib-version+ "2.13.8")
 (def +version+ (str +lib-version+ "-0"))
 (def +lib-folder+ (format "react-color-%s" +lib-version+))
 
@@ -28,7 +28,7 @@
 
 (deftask download-react-color []
   (download  :url      (format "https://github.com/casesandberg/react-color/archive/v%s.zip" +lib-version+)
-             :checksum "A6F47AB81F7829F88D46BAAF783E504F"
+             :checksum "1d0d832d217a675cb9dcf4618c66c01a"
              :unzip    true))
 
 (def webpack-file-name "webpack.config.js")
@@ -50,7 +50,7 @@
                   (io/file tmp +lib-folder+ "webpack-cljsjs.config.js"))
                 (binding [*sh-dir* (str (io/file tmp +lib-folder+))]
                          ((sh "npm" "install" "--ignore-scripts"))
-                         ((sh "npm" "install" "webpack"))
+                         ((sh "npm" "install" "webpack@3"))
                          ((sh "./node_modules/.bin/webpack" "--config" "webpack-cljsjs.config.js")))
                 (-> fileset (boot/add-resource tmp) boot/commit!))))
 

--- a/react-color/resources/cljsjs/react-color/common/react-color.ext.js
+++ b/react-color/resources/cljsjs/react-color/common/react-color.ext.js
@@ -4,7 +4,7 @@ var ReactColor = {
     "ChromePicker": {},
     "CirclePicker": {},
     "CompactPicker": {},
-    "GitHubPicker": {},
+    "GithubPicker": {},
     "HuePicker": {},
     "MaterialPicker": {},
     "PhotoshopPicker": {},
@@ -12,5 +12,5 @@ var ReactColor = {
     "SliderPicker": {},
     "SwatchesPicker": {},
     "TwitterPicker": {},
-    "ColorWrapPicker": {}
+    "CustomPicker": {}
 }


### PR DESCRIPTION
Requires PR #1554 

Updated react-color to 2.13.8. Updated to the latest boot-cljsjs, and added checksums & deps.


Note: Latest is 2.14.0, but there is no release zip, an issue has been added and I will follow up with an update when that is rectified.