### PR TITLE
[material-components] Update to 0.34.1

### DIFF
--- a/material-components/boot-cljsjs-checksums.edn
+++ b/material-components/boot-cljsjs-checksums.edn
@@ -1,0 +1,4 @@
+{"cljsjs/material-components/development/material-components.inc.js"
+ "0F284D18E6BDC3BDC07CB04C34A11C1D",
+ "cljsjs/material-components/production/material-components.min.inc.js"
+ "4909DB75333B0E17BC2DF274C1D3B3B9"}

--- a/material-components/build.boot
+++ b/material-components/build.boot
@@ -57,4 +57,4 @@
    (deps-cljs :name "cljsjs.material-components")
    (pom)
    (jar)
-   (validate-checksums))))
+   (validate-checksums)))

--- a/material-components/build.boot
+++ b/material-components/build.boot
@@ -8,7 +8,7 @@
          '[clojure.java.io :as io]
          '[boot.util :refer [dosh]])
 
-(def +lib-version+ "0.25.0")
+(def +lib-version+ "0.34.1")
 (def +version+ (str +lib-version+ "-0"))
 
 (task-options!
@@ -42,12 +42,12 @@
   (task-options! push {:ensure-branch nil})
   (comp
    (download :url (str "https://github.com/material-components/material-components-web/archive/v" +lib-version+ ".zip")
-             :checksum "0c5101cc2b9d0fbe5515c1262ab17d52"
              :unzip true)
 
    (build-material-components)
 
    (sift :move {#"^material-components-web-[^/]*/build/material-components-web.js$"      "cljsjs/material-components/development/material-components.inc.js"
+                #"^material-components-web-[^/]*/build/material-components-web.js.map$"     "cljsjs/material-components/development/material-components-web.js.map"
                 #"^material-components-web-[^/]*/build/material-components-web.css$"     "cljsjs/material-components/development/material-components.inc.css"
                 #"^material-components-web-[^/]*/build/material-components-web.min.js$"  "cljsjs/material-components/production/material-components.min.inc.js"
                 #"^material-components-web-[^/]*/build/material-components-web.min.css$" "cljsjs/material-components/production/material-components.min.inc.css"
@@ -56,4 +56,5 @@
    (sift :include #{#"^cljsjs"})
    (deps-cljs :name "cljsjs.material-components")
    (pom)
-   (jar)))
+   (jar)
+   (validate-checksums))))


### PR DESCRIPTION
I believe there are large changes that happened in this version upgrade, including seeming to obviate the need for some of the externs data.

It also adds the checksum data, so this should be more secure than previously.

It works locally for what I've used older versions for.