### PR TITLE
[react-datepicker] Fixes improper cljsjs.react.dom require

### DIFF
--- a/react-datepicker/README.md
+++ b/react-datepicker/README.md
@@ -2,7 +2,7 @@
 
 [](dependency)
 ```clojure
-[cljsjs/react-datepicker "1.4.0-0"] ;; latest release
+[cljsjs/react-datepicker "1.4.0-1"] ;; latest release
 ```
 [](/dependency)
 

--- a/react-datepicker/build.boot
+++ b/react-datepicker/build.boot
@@ -1,13 +1,13 @@
 (set-env!
  :resource-paths #{"resources"}
  :dependencies '[[cljsjs/boot-cljsjs "0.10.0" :scope "test"]
-                 [cljsjs/react "16.3.0-0"]
-                 [cljsjs/react-dom "16.3.0-0"]
+                 [cljsjs/react "16.3.0-1"]
+                 [cljsjs/react-dom "16.3.0-1"]
                  [cljsjs/moment "2.22.0-0"]
                  [cljsjs/react-onclickoutside "6.7.1-0"]])
 
 (def +lib-version+ "1.4.0")
-(def +version+ (str +lib-version+ "-0"))
+(def +version+ (str +lib-version+ "-1"))
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
@@ -32,7 +32,7 @@
    (sift :include #{#"^cljsjs"})
    (deps-cljs :name "cljsjs.react-datepicker"
               :requires ["cljsjs.react"
-                         "cljsjs.react-dom"
+                         "cljsjs.react.dom"
                          "cljsjs.moment"
                          "cljsjs.react-onclickoutside"])
    (pom)


### PR DESCRIPTION
Fixes improperly named cljsjs.react.dom require and bumps to latest increment of current react libraries.