### PR TITLE
[react-datepicker] Pull in fixed react-onclickoutside and other needed deps

### DIFF
--- a/react-datepicker/README.md
+++ b/react-datepicker/README.md
@@ -2,7 +2,7 @@
 
 [](dependency)
 ```clojure
-[cljsjs/react-datepicker "1.4.0-1"] ;; latest release
+[cljsjs/react-datepicker "1.4.0-2"] ;; latest release
 ```
 [](/dependency)
 

--- a/react-datepicker/build.boot
+++ b/react-datepicker/build.boot
@@ -4,10 +4,10 @@
                  [cljsjs/react "16.3.0-1"]
                  [cljsjs/react-dom "16.3.0-1"]
                  [cljsjs/moment "2.22.0-0"]
-                 [cljsjs/react-onclickoutside "6.7.1-0"]])
+                 [cljsjs/react-onclickoutside "6.7.1-1"]])
 
 (def +lib-version+ "1.4.0")
-(def +version+ (str +lib-version+ "-1"))
+(def +version+ (str +lib-version+ "-2"))
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 

--- a/react-datepicker/build.boot
+++ b/react-datepicker/build.boot
@@ -3,7 +3,10 @@
  :dependencies '[[cljsjs/boot-cljsjs "0.10.0" :scope "test"]
                  [cljsjs/react "16.3.0-1"]
                  [cljsjs/react-dom "16.3.0-1"]
+                 [cljsjs/prop-types "15.6.0-0"]
                  [cljsjs/moment "2.22.0-0"]
+                 [cljsjs/react-popper "0.10.1-0"]
+                 [cljsjs/classnames "2.2.5-0"]
                  [cljsjs/react-onclickoutside "6.7.1-1"]])
 
 (def +lib-version+ "1.4.0")
@@ -33,7 +36,10 @@
    (deps-cljs :name "cljsjs.react-datepicker"
               :requires ["cljsjs.react"
                          "cljsjs.react.dom"
+                         "cljsjs.prop-types"
+                         "cljsjs.classnames"
                          "cljsjs.moment"
+                         "cljsjs.react-popper"
                          "cljsjs.react-onclickoutside"])
    (pom)
    (jar)


### PR DESCRIPTION
Pulls in fixed react-onclickoutside with proper react-dom require.

Will not build properly until https://github.com/cljsjs/packages/pull/1567, https://github.com/cljsjs/packages/pull/1569, https://github.com/cljsjs/packages/pull/1570, and https://github.com/cljsjs/packages/pull/1571 are merged.