### PR TITLE
[react-sticky] Update to version 6.0.2

### DIFF
--- a/react-sticky/boot-cljsjs-checksums.edn
+++ b/react-sticky/boot-cljsjs-checksums.edn
@@ -1,0 +1,4 @@
+{"cljsjs/react-sticky/development/react-sticky.inc.js"
+ "3B002A705C37F0A9297EC50040DBCBEE",
+ "cljsjs/react-sticky/production/react-sticky.min.inc.js"
+ "284F86242B1ED9A25B8BBF89F9902A59"}

--- a/react-sticky/build.boot
+++ b/react-sticky/build.boot
@@ -1,12 +1,13 @@
 (set-env!
   :resource-paths #{"resources"}
   :dependencies '[[cljsjs/boot-cljsjs "0.9.0"  :scope "test"]
-                  [cljsjs/react "15.3.1-0"]
-                  [cljsjs/react-dom "15.3.1-0"]])
+                  [cljsjs/prop-types "15.6.0-0"]
+                  [cljsjs/react "15.6.2-0"]
+                  [cljsjs/react-dom "15.6.2-0"]])
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
-(def +lib-version+ "6.0.1")
+(def +lib-version+ "6.0.2")
 (def +version+ (str +lib-version+ "-0"))
 (def +lib-folder+ (format "react-sticky-%s" +lib-version+))
 
@@ -29,7 +30,6 @@
 
 (deftask download-react-sticky []
   (download :url url
-            :checksum "371FACEE629677CE015B5AF3AE72651E"
             :unzip true))
 
 (def webpack-file-name "webpack.config.js")
@@ -64,7 +64,8 @@
             :out "cljsjs/react-sticky/production/react-sticky.min.inc.js")
 
     (deps-cljs :name "cljsjs.react-sticky"
-               :requires ["cljsjs.react" "cljsjs.react.dom"])
+               :requires ["cljsjs.prop-types" "cljsjs.react" "cljsjs.react.dom"])
     (pom)
-    (jar)))
+    (jar)
+    (validate-checksums)))
 

--- a/react-sticky/resources/webpack.config.js
+++ b/react-sticky/resources/webpack.config.js
@@ -10,8 +10,8 @@ module.exports = {
   },
   externals: {
     "react": "React",
-      "react-dom": "ReactDOM",
-      "prop-types": "PropTypes"
+    "react-dom": "ReactDOM",
+    "prop-types": "PropTypes"
   },
   module: {
     loaders: [


### PR DESCRIPTION
Update React Sticky to latest version as there have been a number of small bug fixes since version 6.0.1.

Update checksum validation
Add checksum file
Update cljsjs dependencies
Fix minor indentation issue in webpack.config.js

<!--
PR Checklist

Have you read either:
https://github.com/cljsjs/packages/wiki/Creating-Packages
https://github.com/cljsjs/packages/wiki/Updating-packages

Did you follow contribution guidelines:
https://github.com/cljsjs/packages/blob/master/CONTRIBUTING.md

Did you remember to run package script locally and commit
boot-cljsjs-checksum.edn file changes?

boot package install
-->
