### PR TITLE
[react-popper] Patch upgrade to fix dep

### DIFF
--- a/react-popper/README.md
+++ b/react-popper/README.md
@@ -2,7 +2,7 @@
 
 [](dependency)
 ```clojure
-[cljsjs/react-popper "0.10.1-0"] ;; latest release
+[cljsjs/react-popper "0.10.1-1"] ;; latest release
 ```
 [](/dependency)
 

--- a/react-popper/build.boot
+++ b/react-popper/build.boot
@@ -3,11 +3,11 @@
  :dependencies '[[cljsjs/boot-cljsjs "0.10.0"  :scope "test"]
                  [cljsjs/react "16.3.0-1"]
                  [cljsjs/react-dom "16.3.0-1"]
-                 [cljsjs/popperjs "1.14.3-0"]
+                 [cljsjs/popperjs "1.14.3-1"]
                  [cljsjs/prop-types "15.6.0-0"]])
 
 (def +lib-version+ "0.10.1")
-(def +version+ (str +lib-version+ "-0"))
+(def +version+ (str +lib-version+ "-1"))
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
@@ -33,4 +33,4 @@
                          "cljsjs.prop-types"])
    (pom)
    (jar)
-   (validate-checksums)))
+   (validate)))


### PR DESCRIPTION
Get the new version of PopperJS that isn't broken.

Requires https://github.com/cljsjs/packages/pull/1582 to build properly.