### PR TITLE
[react-datepicker] Upgrade to 1.4.1

### DIFF
--- a/react-datepicker/README.md
+++ b/react-datepicker/README.md
@@ -2,7 +2,7 @@
 
 [](dependency)
 ```clojure
-[cljsjs/react-datepicker "1.4.0-2"] ;; latest release
+[cljsjs/react-datepicker "1.4.1-0"] ;; latest release
 ```
 [](/dependency)
 
@@ -14,7 +14,7 @@ you can require the packaged library like so:
 (ns application.core
   (:require [cljsjs.react-datepicker]))
 
-(def date-picker (.createFactory js/React (.-default js/DatePicker)))
+(def date-picker (.createFactory js/React js/DatePicker)))
 ```
 
 [flibs]: https://clojurescript.org/reference/packaging-foreign-deps

--- a/react-datepicker/boot-cljsjs-checksums.edn
+++ b/react-datepicker/boot-cljsjs-checksums.edn
@@ -1,4 +1,4 @@
 {"cljsjs/react-datepicker/development/react-datepicker.inc.js"
- "CBBF63077C34948714580CE6B63178A0",
+ "992FFCCE0C1E6E963CA5068EA6CEAC5C",
  "cljsjs/react-datepicker/production/react-datepicker.min.inc.js"
- "CBBF63077C34948714580CE6B63178A0"}
+ "992FFCCE0C1E6E963CA5068EA6CEAC5C"}

--- a/react-datepicker/build.boot
+++ b/react-datepicker/build.boot
@@ -5,12 +5,12 @@
                  [cljsjs/react-dom "16.3.0-1"]
                  [cljsjs/prop-types "15.6.0-0"]
                  [cljsjs/moment "2.22.0-0"]
-                 [cljsjs/react-popper "0.10.1-0"]
+                 [cljsjs/react-popper "0.10.1-1"]
                  [cljsjs/classnames "2.2.5-0"]
                  [cljsjs/react-onclickoutside "6.7.1-1"]])
 
-(def +lib-version+ "1.4.0")
-(def +version+ (str +lib-version+ "-2"))
+  (def +lib-version+ "1.4.1")
+(def +version+ (str +lib-version+ "-0"))
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
@@ -43,4 +43,4 @@
                          "cljsjs.react-onclickoutside"])
    (pom)
    (jar)
-   (validate-checksums)))
+   (validate)))


### PR DESCRIPTION
* Upgraded to latest react-datepicker
* Fix Readme instructions
* Get fixed react-popper (with fixed popperjs)

Requires https://github.com/cljsjs/packages/pull/1583 to build properly