### PR TITLE
Update semantic-ui-react 0.79.1

### DIFF
--- a/semantic-ui-react/README.md
+++ b/semantic-ui-react/README.md
@@ -4,7 +4,7 @@ http://react.semantic-ui.com
 
 [](dependency)
 ```clojure
-[cljsjs/semantic-ui-react "0.79.0-0"] ;; latest release
+[cljsjs/semantic-ui-react "0.79.1-0"] ;; latest release
 ```
 [](/dependency)
 

--- a/semantic-ui-react/README.md
+++ b/semantic-ui-react/README.md
@@ -4,7 +4,7 @@ http://react.semantic-ui.com
 
 [](dependency)
 ```clojure
-[cljsjs/semantic-ui-react "0.78.2-0"] ;; latest release
+[cljsjs/semantic-ui-react "0.79.0-0"] ;; latest release
 ```
 [](/dependency)
 

--- a/semantic-ui-react/boot-cljsjs-checksums.edn
+++ b/semantic-ui-react/boot-cljsjs-checksums.edn
@@ -1,2 +1,2 @@
 {"cljsjs/semantic-ui-react/common/semantic-ui-react.inc.js"
- "63685220EEFCFA3509CC50379629ADCD"}
+ "E8DFBF3C399A5A68512DE12649C7A49F"}

--- a/semantic-ui-react/boot-cljsjs-checksums.edn
+++ b/semantic-ui-react/boot-cljsjs-checksums.edn
@@ -1,2 +1,2 @@
 {"cljsjs/semantic-ui-react/common/semantic-ui-react.inc.js"
- "E8DFBF3C399A5A68512DE12649C7A49F"}
+ "DD5ED55FC27E5C355705AAAD91630441"}

--- a/semantic-ui-react/build.boot
+++ b/semantic-ui-react/build.boot
@@ -4,7 +4,7 @@
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
-(def +lib-version+ "0.78.2")
+(def +lib-version+ "0.79.0")
 (def +version+ (str +lib-version+ "-0"))
 
 (task-options!
@@ -23,7 +23,7 @@
                :provides ["cljsjs.semantic-ui-react"]
                :global-exports '{cljsjs.semantic-ui-react semanticUIReact})
     (pom :project 'cljsjs/semantic-ui-react
-         :dependencies [['cljsjs/react "15.0.0-0"]
-                        ['cljsjs/react-dom "15.0.0-0"]])
+         :dependencies [['cljsjs/react "16.0.0-0"]
+                        ['cljsjs/react-dom "16.0.0-0"]])
     (jar)
     (validate)))

--- a/semantic-ui-react/build.boot
+++ b/semantic-ui-react/build.boot
@@ -4,7 +4,7 @@
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
-(def +lib-version+ "0.79.0")
+(def +lib-version+ "0.79.1")
 (def +version+ (str +lib-version+ "-0"))
 
 (task-options!


### PR DESCRIPTION
changed version semantic-ui to 0.79.1

https://github.com/Semantic-Org/Semantic-UI-React/compare/v0.78.2...v0.79.1

change version of react (and react.dom) to 16.xx like it describe in package.json 
https://github.com/Semantic-Org/Semantic-UI-React/blob/v0.79.1/package.json#L122

changed tested with 0.79.0 version and after for 0.79.1 latest tag