### PR TITLE
react-motion 0.5.2 + :global-exports

### DIFF
--- a/react-motion/README.md
+++ b/react-motion/README.md
@@ -15,4 +15,11 @@ you can require the packaged library like so:
   (:require cljsjs.react-motion))
 ```
 
+This package also supports `:global-exports`:
+
+```
+(ns application.core
+  (:require [react-motion :as rm :refer [Motion]]))
+```
+
 [flibs]: https://clojurescript.org/reference/packaging-foreign-deps

--- a/react-motion/boot-cljsjs-checksums.edn
+++ b/react-motion/boot-cljsjs-checksums.edn
@@ -1,0 +1,4 @@
+{"cljsjs/react-motion/development/react-motion.inc.js"
+ "10669785248AA7E3EFA3F5E83DBA6804",
+ "cljsjs/react-motion/production/react-motion.min.inc.js"
+ "CA8A3CE13EA4C25A692183AF09B3B2A5"}

--- a/react-motion/build.boot
+++ b/react-motion/build.boot
@@ -9,7 +9,7 @@
          '[clojure.java.io :as io]
          '[boot.util :refer [sh]])
 
-(def +lib-version+ "0.5.0")
+(def +lib-version+ "0.5.2")
 (def +version+ (str +lib-version+ "-0"))
 (def +lib-folder+ (format "react-motion-%s" +lib-version+))
 
@@ -23,7 +23,7 @@
 
 (deftask download-react-motion []
   (download :url      (format "https://github.com/chenglou/react-motion/archive/v%s.zip" +lib-version+)
-            :checksum "75e1c454fedc2ff19bf79817d57bdc48"
+            :checksum "426d31dd7502fdc141af7371a43f356a"
             :unzip    true))
 
 (deftask build-react-motion []
@@ -48,8 +48,10 @@
                  "cljsjs/react-motion/development/react-motion.inc.js"})
     (minify :in "cljsjs/react-motion/development/react-motion.inc.js"
             :out "cljsjs/react-motion/production/react-motion.min.inc.js")
-    (sift :include #{#"^cljsjs"})
-    (deps-cljs :name "cljsjs.react-motion"
-               :requires ["cljsjs.react"])
+    (sift :include #{#"^cljsjs" #"^deps\.cljs"})
+    (deps-cljs :provides ["react-motion" "cljsjs.react-motion"]
+               :requires ["cljsjs.react"]
+               :global-exports '{react-motion ReactMotion})
     (pom)
-    (jar)))
+    (jar)
+    (validate)))


### PR DESCRIPTION
Bump react-motion to the latest version, and add support for :global-exports.

Tried locally with `boot package install target`, also tried out the :global-exports support.

<!--
PR Checklist

Have you read either:
https://github.com/cljsjs/packages/wiki/Creating-Packages
https://github.com/cljsjs/packages/wiki/Updating-packages

Did you follow contribution guidelines:
https://github.com/cljsjs/packages/blob/master/CONTRIBUTING.md

Did you remember to run package script locally and commit
boot-cljsjs-checksum.edn file changes?

boot package install
-->
