### PR TITLE
[semantic-ui-react] Bump to 0.80.0

### DIFF
--- a/semantic-ui-react/boot-cljsjs-checksums.edn
+++ b/semantic-ui-react/boot-cljsjs-checksums.edn
@@ -1,2 +1,2 @@
 {"cljsjs/semantic-ui-react/common/semantic-ui-react.inc.js"
- "DD5ED55FC27E5C355705AAAD91630441"}
+ "8EDDC361F623ADA066EC5DBC1730F12D"}

--- a/semantic-ui-react/build.boot
+++ b/semantic-ui-react/build.boot
@@ -4,7 +4,7 @@
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
-(def +lib-version+ "0.79.1")
+(def +lib-version+ "0.80.0")
 (def +version+ (str +lib-version+ "-0"))
 
 (task-options!


### PR DESCRIPTION
Bumped semantic-ui-react to 0.80.0. Left the existing "empty" externs file as
is, updated checksums.