### PR TITLE
Add license to cljsjs/google-analytics

### DIFF
--- a/google-analytics/build.boot
+++ b/google-analytics/build.boot
@@ -13,7 +13,7 @@
        :description "Google Universal Analytics (analytics.js)"
        :url         "https://developers.google.com/analytics/devguides/collection/analyticsjs/"
        :scm         {:url "https://github.com/cljsjs/packages"}
-       :license     {"" ""}})
+       :license     {"Apache v2" "http://www.apache.org/licenses/LICENSE-2.0"}})
 
 (deftask package []
   (comp


### PR DESCRIPTION
Adds the Apache v2 license, which is the license of the google-analytics library