### PR TITLE
[libphonenumber] Fix 'is not a relative path' exception cljsjs.libphonenumber "8.4.1-2"

### DIFF
--- a/libphonenumber/build.boot
+++ b/libphonenumber/build.boot
@@ -5,7 +5,7 @@
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
 (def +lib-version+ "8.4.1")
-(def +version+ (str +lib-version+ "-1"))
+(def +version+ (str +lib-version+ "-2"))
 
 (task-options!
  pom  {:project     'cljsjs/libphonenumber

--- a/libphonenumber/resources/deps.cljs
+++ b/libphonenumber/resources/deps.cljs
@@ -1,2 +1,2 @@
-{:libs ["cljsjs/libphonenumber/development/"]
+{:libs ["cljsjs/libphonenumber/development"]
  :externs []}


### PR DESCRIPTION
The trailing slash in deps.cljs -> :libs causes an exception [1] to be thrown when this library is used in conjunction with figwheel 0.5.16 (latest at PR time).

Updating from `:checksum` to `validate` call produced an empty `boot-cljsjs-checksums.edn`

[1]
```
Failed to compile build :dev from ["src/cljs" "src/cljc" "checkouts/nsfw/src/cljs" "checkouts/nsfw/src/cljc"] in 27.072 seconds.
 ----  Exception    ----

   /cljs/18n/phonemetadata.pb.js is not a relative path

 ----  Exception Stack Trace  ----

 java.lang.IllegalArgumentException: /cljs/18n/phonemetadata.pb.js is not a relative path
  at clojure.java.io$as_relative_path.invokeStatic (io.clj:414)
     clojure.java.io$file.invokeStatic (io.clj:426)
     clojure.java.io$file.invoke (io.clj:418)
     cljs.closure$write_javascript.invokeStatic (closure.clj:1857)
     cljs.closure$write_javascript.invoke (closure.clj:1850)
     cljs.closure$source_on_disk.invokeStatic (closure.clj:1899)
     cljs.closure$source_on_disk.invoke (closure.clj:1894)
     cljs.closure$output_unoptimized$fn__5529.invoke (closure.clj:1941)
     clojure.core$map$fn__5587.invoke (core.clj:2747)
...
```

