### PR TITLE
[react] Upgrade react to 16.4.0

### DIFF
--- a/react/README.md
+++ b/react/README.md
@@ -2,7 +2,7 @@
 
 [](dependency)
 ```clojure
-[cljsjs/react "16.3.2-0"] ;; latest release
+[cljsjs/react "16.4.0-0"] ;; latest release
 ```
 [](/dependency)
 

--- a/react/boot-cljsjs-checksums.edn
+++ b/react/boot-cljsjs-checksums.edn
@@ -1,16 +1,16 @@
 {"cljsjs/react-dom/development/react-dom-server.browser.inc.js"
- "139CAD540E1D9414FCFFF9F6FF5086FD",
+ "CEA8117656CC225F06AE8AB88AB7F6DB",
  "cljsjs/react-dom/development/react-dom-test-utils.inc.js"
- "0E3B605CEB8058C8B7EABE21E38932BF",
+ "0E91236248FE8785FD45C6D12F563AD1",
  "cljsjs/react-dom/development/react-dom.inc.js"
- "A6AB848B2C3587AF1C6203B703847D74",
+ "E1913268E47E970FAAD1430A5BF76122",
  "cljsjs/react-dom/production/react-dom-server.browser.min.inc.js"
- "8B2F54D926A781BBA4B4A1DC6C1834F1",
+ "20E7CD3BC87B6A47CA7C43ECD4F35471",
  "cljsjs/react-dom/production/react-dom-test-utils.min.inc.js"
- "91A391F0E1A6344AEB1995D391496121",
+ "A3C98918C2915C7DDE67C985EF0EFE4E",
  "cljsjs/react-dom/production/react-dom.min.inc.js"
- "58DA31A0F4BB32872E91807E617C9EF6",
+ "20DED07CB136097E30973F8B23F7E75C",
  "cljsjs/react/development/react.inc.js"
- "DEC4EFA587E8F48A39E7979E2A83D45A",
+ "BAC3C0BBC44F7BDFF6DA7A78F60CF6C4",
  "cljsjs/react/production/react.min.inc.js"
- "CDF9611DF0CC6D0A0DB5DE1AF4CF4697"}
+ "4C01FE07C8933892CE22A6F334E1510B"}

--- a/react/build.boot
+++ b/react/build.boot
@@ -1,10 +1,10 @@
 (set-env!
-  :resource-paths #{"resources"}
-  :dependencies '[[cljsjs/boot-cljsjs "0.10.0" :scope "test"]])
+ :resource-paths #{"resources"}
+ :dependencies '[[cljsjs/boot-cljsjs "0.10.0" :scope "test"]])
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
-(def +lib-version+ "16.3.2")
+(def +lib-version+ "16.4.0")
 (def +version+ (str +lib-version+ "-0"))
 
 (task-options!
@@ -17,62 +17,62 @@
 
 (defn download-react [project part]
   (comp
-    (download :url (format "https://unpkg.com/%s@%s/umd/%s.development.js" project +lib-version+ part)
-              :target (format "cljsjs/%1$s/development/%2$s.inc.js" project part))
-    (download :url (format "https://unpkg.com/%s@%s/umd/%s.production.min.js" project +lib-version+ part)
-              :target (format "cljsjs/%1$s/production/%2$s.min.inc.js" project part))))
+   (download :url (format "https://unpkg.com/%s@%s/umd/%s.development.js" project +lib-version+ part)
+             :target (format "cljsjs/%1$s/development/%2$s.inc.js" project part))
+   (download :url (format "https://unpkg.com/%s@%s/umd/%s.production.min.js" project +lib-version+ part)
+             :target (format "cljsjs/%1$s/production/%2$s.min.inc.js" project part))))
 
 (deftask package-react []
   (with-files (fn [x] (#{"react.ext.js"} (.getName (tmp-file x))))
     (comp
-      (download-react "react" "react")
-      (deps-cljs :provides ["react" "cljsjs.react"]
-                 :requires []
-                 :global-exports '{react React})
-      (pom :project 'cljsjs/react
-           :dependencies [])
-      (show :fileset true)
-      (jar))))
+     (download-react "react" "react")
+     (deps-cljs :provides ["react" "cljsjs.react"]
+                :requires []
+                :global-exports '{react React})
+     (pom :project 'cljsjs/react
+          :dependencies [])
+     (show :fileset true)
+     (jar))))
 
 (deftask package-dom []
   (with-files (fn [x] (re-find #"react-dom.*\.ext\.js" (.getName (tmp-file x))))
     (comp
-      (download-react "react-dom" "react-dom")
-      (download-react "react-dom" "react-dom-server.browser")
-      (download-react "react-dom" "react-dom-test-utils")
-      (deps-cljs :foreign-libs [{:file #"react-dom\.inc\.js"
-                                 :file-min #"react-dom\.min\.inc\.js"
-                                 :provides ["react-dom" "cljsjs.react.dom"]
-                                 :requires ["react"]
-                                 :global-exports '{react-dom ReactDOM}}
-                                {:file #"react-dom-server\.browser\.inc\.js"
-                                 :file-min #"react-dom-server\.browser\.min\.inc\.js"
-                                 :provides ["react-dom/server" "cljsjs.react.dom.server"]
-                                 :requires ["react-dom"]
-                                 :global-exports '{react-dom/server ReactDOMServer}}
-                                {:file #"react-dom-test-utils\.inc\.js"
-                                 :file-min #"react-dom-test-utils\.min\.inc\.js"
-                                 :provides ["react-dom/test-utils" "cljsjs.react.dom.test-utils"]
-                                 :requires ["react-dom"]
-                                 :global-exports '{react-dom/test-utils ReactTestUtils}}]
-                 :externs [#"react-dom.*\.ext\.js"])
-      (pom :project 'cljsjs/react-dom
-           :dependencies [['cljsjs/react +version+]])
-      (show :fileset true)
-      (jar))))
+     (download-react "react-dom" "react-dom")
+     (download-react "react-dom" "react-dom-server.browser")
+     (download-react "react-dom" "react-dom-test-utils")
+     (deps-cljs :foreign-libs [{:file #"react-dom\.inc\.js"
+                                :file-min #"react-dom\.min\.inc\.js"
+                                :provides ["react-dom" "cljsjs.react.dom"]
+                                :requires ["react"]
+                                :global-exports '{react-dom ReactDOM}}
+                               {:file #"react-dom-server\.browser\.inc\.js"
+                                :file-min #"react-dom-server\.browser\.min\.inc\.js"
+                                :provides ["react-dom/server" "cljsjs.react.dom.server"]
+                                :requires ["react-dom"]
+                                :global-exports '{react-dom/server ReactDOMServer}}
+                               {:file #"react-dom-test-utils\.inc\.js"
+                                :file-min #"react-dom-test-utils\.min\.inc\.js"
+                                :provides ["react-dom/test-utils" "cljsjs.react.dom.test-utils"]
+                                :requires ["react-dom"]
+                                :global-exports '{react-dom/test-utils ReactTestUtils}}]
+                :externs [#"react-dom.*\.ext\.js"])
+     (pom :project 'cljsjs/react-dom
+          :dependencies [['cljsjs/react +version+]])
+     (show :fileset true)
+     (jar))))
 
 (deftask package-dom-server []
   (with-files (constantly nil)
     (comp
-      (pom :project 'cljsjs/react-dom-server
-           :description "React-dom-server package is now deprecated, the server file is included in react-dom package."
-           :dependencies [['cljsjs/react-dom +version+]])
-      (show :fileset true)
-      (jar))))
+     (pom :project 'cljsjs/react-dom-server
+          :description "React-dom-server package is now deprecated, the server file is included in react-dom package."
+          :dependencies [['cljsjs/react-dom +version+]])
+     (show :fileset true)
+     (jar))))
 
 (deftask package []
   (comp
-    (package-react)
-    (package-dom)
-    (package-dom-server)
-    (validate)))
+   (package-react)
+   (package-dom)
+   (package-dom-server)
+   (validate)))

--- a/react/build.boot
+++ b/react/build.boot
@@ -1,6 +1,6 @@
 (set-env!
- :resource-paths #{"resources"}
- :dependencies '[[cljsjs/boot-cljsjs "0.10.0" :scope "test"]])
+  :resource-paths #{"resources"}
+  :dependencies '[[cljsjs/boot-cljsjs "0.10.0" :scope "test"]])
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
@@ -17,62 +17,62 @@
 
 (defn download-react [project part]
   (comp
-   (download :url (format "https://unpkg.com/%s@%s/umd/%s.development.js" project +lib-version+ part)
-             :target (format "cljsjs/%1$s/development/%2$s.inc.js" project part))
-   (download :url (format "https://unpkg.com/%s@%s/umd/%s.production.min.js" project +lib-version+ part)
-             :target (format "cljsjs/%1$s/production/%2$s.min.inc.js" project part))))
+    (download :url (format "https://unpkg.com/%s@%s/umd/%s.development.js" project +lib-version+ part)
+              :target (format "cljsjs/%1$s/development/%2$s.inc.js" project part))
+    (download :url (format "https://unpkg.com/%s@%s/umd/%s.production.min.js" project +lib-version+ part)
+              :target (format "cljsjs/%1$s/production/%2$s.min.inc.js" project part))))
 
 (deftask package-react []
   (with-files (fn [x] (#{"react.ext.js"} (.getName (tmp-file x))))
     (comp
-     (download-react "react" "react")
-     (deps-cljs :provides ["react" "cljsjs.react"]
-                :requires []
-                :global-exports '{react React})
-     (pom :project 'cljsjs/react
-          :dependencies [])
-     (show :fileset true)
-     (jar))))
+      (download-react "react" "react")
+      (deps-cljs :provides ["react" "cljsjs.react"]
+                 :requires []
+                 :global-exports '{react React})
+      (pom :project 'cljsjs/react
+           :dependencies [])
+      (show :fileset true)
+      (jar))))
 
 (deftask package-dom []
   (with-files (fn [x] (re-find #"react-dom.*\.ext\.js" (.getName (tmp-file x))))
     (comp
-     (download-react "react-dom" "react-dom")
-     (download-react "react-dom" "react-dom-server.browser")
-     (download-react "react-dom" "react-dom-test-utils")
-     (deps-cljs :foreign-libs [{:file #"react-dom\.inc\.js"
-                                :file-min #"react-dom\.min\.inc\.js"
-                                :provides ["react-dom" "cljsjs.react.dom"]
-                                :requires ["react"]
-                                :global-exports '{react-dom ReactDOM}}
-                               {:file #"react-dom-server\.browser\.inc\.js"
-                                :file-min #"react-dom-server\.browser\.min\.inc\.js"
-                                :provides ["react-dom/server" "cljsjs.react.dom.server"]
-                                :requires ["react-dom"]
-                                :global-exports '{react-dom/server ReactDOMServer}}
-                               {:file #"react-dom-test-utils\.inc\.js"
-                                :file-min #"react-dom-test-utils\.min\.inc\.js"
-                                :provides ["react-dom/test-utils" "cljsjs.react.dom.test-utils"]
-                                :requires ["react-dom"]
-                                :global-exports '{react-dom/test-utils ReactTestUtils}}]
-                :externs [#"react-dom.*\.ext\.js"])
-     (pom :project 'cljsjs/react-dom
-          :dependencies [['cljsjs/react +version+]])
-     (show :fileset true)
-     (jar))))
+      (download-react "react-dom" "react-dom")
+      (download-react "react-dom" "react-dom-server.browser")
+      (download-react "react-dom" "react-dom-test-utils")
+      (deps-cljs :foreign-libs [{:file #"react-dom\.inc\.js"
+                                 :file-min #"react-dom\.min\.inc\.js"
+                                 :provides ["react-dom" "cljsjs.react.dom"]
+                                 :requires ["react"]
+                                 :global-exports '{react-dom ReactDOM}}
+                                {:file #"react-dom-server\.browser\.inc\.js"
+                                 :file-min #"react-dom-server\.browser\.min\.inc\.js"
+                                 :provides ["react-dom/server" "cljsjs.react.dom.server"]
+                                 :requires ["react-dom"]
+                                 :global-exports '{react-dom/server ReactDOMServer}}
+                                {:file #"react-dom-test-utils\.inc\.js"
+                                 :file-min #"react-dom-test-utils\.min\.inc\.js"
+                                 :provides ["react-dom/test-utils" "cljsjs.react.dom.test-utils"]
+                                 :requires ["react-dom"]
+                                 :global-exports '{react-dom/test-utils ReactTestUtils}}]
+                 :externs [#"react-dom.*\.ext\.js"])
+      (pom :project 'cljsjs/react-dom
+           :dependencies [['cljsjs/react +version+]])
+      (show :fileset true)
+      (jar))))
 
 (deftask package-dom-server []
   (with-files (constantly nil)
     (comp
-     (pom :project 'cljsjs/react-dom-server
-          :description "React-dom-server package is now deprecated, the server file is included in react-dom package."
-          :dependencies [['cljsjs/react-dom +version+]])
-     (show :fileset true)
-     (jar))))
+      (pom :project 'cljsjs/react-dom-server
+           :description "React-dom-server package is now deprecated, the server file is included in react-dom package."
+           :dependencies [['cljsjs/react-dom +version+]])
+      (show :fileset true)
+      (jar))))
 
 (deftask package []
   (comp
-   (package-react)
-   (package-dom)
-   (package-dom-server)
-   (validate)))
+    (package-react)
+    (package-dom)
+    (package-dom-server)
+    (validate)))


### PR DESCRIPTION
I did not update the externs as it appears they are generated differently than other packages and the ones automatically generated using React via unpkg are unlike the ones we have currently (they are much shorter).

@Deraen Let me know what is needed to upgrade externs (if it's anything special) and I can update this PR.

I did notice it looks like we have 'React 15' externs at the top then additions for 'React 16.3' on the bottom. I'm unaware if that is an intentional separation.
