### PR TITLE
[slate-react] Upgrade to 0.12.6

### DIFF
--- a/slate-react/README.md
+++ b/slate-react/README.md
@@ -2,7 +2,7 @@
 
 [](dependency)
 ```clojure
-[cljsjs/slate-react "0.12.4-0"] ;; latest release
+[cljsjs/slate-react "0.12.6-0"] ;; latest release
 ```
 [](/dependency)
 

--- a/slate-react/boot-cljsjs-checksums.edn
+++ b/slate-react/boot-cljsjs-checksums.edn
@@ -1,0 +1,4 @@
+{"cljsjs/slate-react/development/slate-react.inc.js"
+ "052CCAA46B4A2AFC1F5B86B2543F8C9B",
+ "cljsjs/slate-react/production/slate-react.min.inc.js"
+ "0BE7E18FE7D4DCED1273BC97939C717B"}

--- a/slate-react/build.boot
+++ b/slate-react/build.boot
@@ -1,12 +1,12 @@
-(def +lib-version+ "0.12.4")
+(def +lib-version+ "0.12.6")
 (def +version+ (str +lib-version+ "-0"))
 
 (set-env!
  :resource-paths #{"resources"}
  :dependencies '[[cljsjs/boot-cljsjs "0.10.0" :scope "test"]
-                 [cljsjs/react "16.3.0-0"]
-                 [cljsjs/react-dom "16.3.0-0"]
-                 [cljsjs/slate "0.33.4-0"]])
+                 [cljsjs/react "16.3.2-0"]
+                 [cljsjs/react-dom "16.3.2-0"]
+                 [cljsjs/slate "0.33.6-0"]])
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
@@ -20,16 +20,13 @@
 
 (deftask package  []
   (comp
-   (download :url (str "https://unpkg.com/slate-react@" +lib-version+  "/dist/slate-react.js")
-             :checksum "0c271702870fb678f261c7429881dae6")
-   (download :url (str "https://unpkg.com/slate-react@" +lib-version+  "/dist/slate-react.min.js")
-             :checksum "cc9e3089ce87205d2e5d72747351d298")
-   (sift :move {#"^slate-react.js$"
-                "cljsjs/slate-react/development/slate-react.inc.js"
-                #"^slate-react.min.js"
-                "cljsjs/slate-react/production/slate-react.min.inc.js"})
+   (download :url (format "https://unpkg.com/slate-react@%s/dist/slate-react.js" +lib-version+)
+             :target "cljsjs/slate-react/development/slate-react.inc.js")
+   (download :url (format "https://unpkg.com/slate-react@%s/dist/slate-react.min.js" +lib-version+)
+             :target "cljsjs/slate-react/production/slate-react.min.inc.js")
    (sift :include #{#"^cljsjs"})
    (deps-cljs :name "cljsjs.slate-react"
               :requires ["cljsjs.react" "cljsjs.react.dom" "cljsjs.slate"])
    (pom)
-   (jar)))
+   (jar)
+   (validate)))


### PR DESCRIPTION
Also did some cleanup and added validation.

Build will fail until https://github.com/cljsjs/packages/pull/1633 is merged.