### PR TITLE
draft-convert initial commit v2.1.2

### DIFF
--- a/draft-convert/README.md
+++ b/draft-convert/README.md
@@ -1,0 +1,20 @@
+# cljsjs/draft-convert
+
+[](dependency)
+```clojure
+[cljsjs/draft-donvert "2.1.2-0"] ;; latest release
+```
+[](/dependency)
+
+This jar comes with `deps.cljs` as used by the [Foreign Libs][flibs] feature
+of the ClojureScript compiler. After adding the above dependency to your project
+you can require the packaged library like so:
+
+```clojure
+(ns application.core
+  (:require cljsjs.draft-convert))
+
+(let [html (.convertToHTML js/DraftConvert (.getCurrentContent editor-state))])
+```
+
+[flibs]: https://clojurescript.org/reference/packaging-foreign-deps

--- a/draft-convert/build.boot
+++ b/draft-convert/build.boot
@@ -1,0 +1,38 @@
+(set-env!
+  :resource-paths #{"resources"}
+  :dependencies '[[cljsjs/boot-cljsjs      "0.10.0"  :scope "test"]
+                  [cljsjs/react            "16.4.0-0"]
+                  [cljsjs/react-dom        "16.4.0-0"]
+                  [cljsjs/react-dom-server "16.4.0-0"]
+                  [cljsjs/immutable        "3.8.1-0" ]])
+
+(require '[cljsjs.boot-cljsjs.packaging :refer :all])
+
+(def +lib-version+ "2.1.2")
+(def +version+ (str +lib-version+ "-0"))
+
+(task-options!
+ pom  {:project     'cljsjs/draft-convert
+       :version     +version+
+       :description "Extensibly serialize & deserialize Draft.js content with HTML"
+       :url         "https://github.com/HubSpot/draft-convert"
+       :scm         {:url "https://github.com/cljsjs/packages"}
+       :license     {"Apache 2.0" "https://www.apache.org/licenses/LICENSE-2.0"}})
+
+(defn cdn-ver [file]
+  (str "https://unpkg.com/draft-convert@" +lib-version+ "/dist/" file))
+
+(deftask package []
+  (comp
+    (download  :url (cdn-ver "draft-convert.js")
+               :target "cljsjs/draft-convert/development/draft-convert.inc.js")
+    (download  :url (cdn-ver "draft-convert.min.js")
+               :target "cljsjs/draft-convert/production/draft-convert.min.inc.js")
+    (deps-cljs :name "cljsjs.draft-convert"
+               :requires ["cljsjs.react"
+                          "cljsjs.react.dom"
+                          "cljsjs.react.dom.server"
+                          "cljsjs.draft-js"
+                          "cljsjs.immutable"])
+    (pom)
+    (jar)))

--- a/draft-convert/resources/cljsjs/draft-convert/common/draft-convert.ext.js
+++ b/draft-convert/resources/cljsjs/draft-convert/common/draft-convert.ext.js
@@ -1,0 +1,4 @@
+var DraftConvert = {};
+DraftConvert.convertFromHTML = function() {};
+DraftConvert.convertToHTML = function() {};
+DraftConvert.parseHTML = function() {};


### PR DESCRIPTION
Add the draft-convert library v2.1.2 for use with draft-js.
