### PR TITLE
[textures] Add d3 dependency and lock version of js file source.

### DIFF
--- a/textures/README.md
+++ b/textures/README.md
@@ -2,7 +2,7 @@
 
 [](dependency)
 ```clojure
-[cljsjs/textures "1.0.3-0"] ;; latest release
+[cljsjs/textures "1.0.3-1"] ;; latest release
 ```
 
 [](/dependency)

--- a/textures/boot-cljsjs-checksums.edn
+++ b/textures/boot-cljsjs-checksums.edn
@@ -1,0 +1,4 @@
+{"cljsjs/textures/development/textures.inc.js"
+ "14ED87DDDDFE4F6E56B9F715F8D11CA6",
+ "cljsjs/textures/production/textures.min.inc.js"
+ "FD3F59384DE2DF265C15AB472A4CC392"}

--- a/textures/build.boot
+++ b/textures/build.boot
@@ -19,8 +19,13 @@
 (deftask package []
   (comp
    (download :url "https://raw.githubusercontent.com/riccardoscalco/textures/83094475a6cc6f58e6d0755cb0e7720f156ec65a/dist/textures.js"
-             :checksum "14ed87ddddfe4f6e56b9f715f8d11ca6")
-   (sift :move {#"textures.js" "cljsjs/textures/development/textures.inc.js"})
+             :checksum "14ed87ddddfe4f6e56b9f715f8d11ca6"
+             :name "textures.inc.js")
+   (sift :move {#"textures\.inc\.js" "cljsjs/textures/development/textures.inc.js"})
+   (download :url "https://raw.githubusercontent.com/riccardoscalco/textures/83094475a6cc6f58e6d0755cb0e7720f156ec65a/dist/textures.js"
+             :checksum "14ed87ddddfe4f6e56b9f715f8d11ca6"
+             :name "textures.min.inc.js")
+   (sift :move {#"textures\.min\.inc\.js" "cljsjs/textures/production/textures.min.inc.js"})
    (sift :include #{#"^cljsjs"})
    (deps-cljs :name "cljsjs.textures"
               :requires ["cljsjs.d3"])

--- a/textures/build.boot
+++ b/textures/build.boot
@@ -5,8 +5,8 @@
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
-(def +lib-version+ "1.0.3")
-(def +version+ (str +lib-version+ "-1"))
+(def +lib-version+ "1.2.0")
+(def +version+ (str +lib-version+ "-0"))
 
 (task-options!
  pom  {:project     'cljsjs/textures
@@ -18,16 +18,17 @@
 
 (deftask package []
   (comp
-   (download :url "https://raw.githubusercontent.com/riccardoscalco/textures/83094475a6cc6f58e6d0755cb0e7720f156ec65a/dist/textures.js"
-             :checksum "14ed87ddddfe4f6e56b9f715f8d11ca6"
-             :name "textures.inc.js")
-   (sift :move {#"textures\.inc\.js" "cljsjs/textures/development/textures.inc.js"})
-   (download :url "https://raw.githubusercontent.com/riccardoscalco/textures/83094475a6cc6f58e6d0755cb0e7720f156ec65a/dist/textures.js"
-             :checksum "14ed87ddddfe4f6e56b9f715f8d11ca6"
-             :name "textures.min.inc.js")
-   (sift :move {#"textures\.min\.inc\.js" "cljsjs/textures/production/textures.min.inc.js"})
+   (download
+    :url (format "https://github.com/riccardoscalco/textures/archive/v%s.zip" +lib-version+)
+    :unzip true)
+   (sift :move {#"^textures.*/dist/textures\.js" "cljsjs/textures/development/textures.inc.js"})
    (sift :include #{#"^cljsjs"})
+   (minify
+    :in "cljsjs/textures/development/textures.inc.js"
+    :out "cljsjs/textures/production/textures.min.inc.js"
+    :lang :ecmascript5)
    (deps-cljs :name "cljsjs.textures"
               :requires ["cljsjs.d3"])
    (pom)
-   (jar)))
+   (jar)
+   (validate)))

--- a/textures/build.boot
+++ b/textures/build.boot
@@ -1,11 +1,12 @@
 (set-env!
-  :resource-paths #{"resources"}
-  :dependencies '[[cljsjs/boot-cljsjs "0.10.0"  :scope "test"]])
+ :resource-paths #{"resources"}
+ :dependencies '[[cljsjs/boot-cljsjs "0.10.0"  :scope "test"]
+                 [cljsjs/d3 "4.12.0-0"]])
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
 (def +lib-version+ "1.0.3")
-(def +version+ (str +lib-version+ "-0"))
+(def +version+ (str +lib-version+ "-1"))
 
 (task-options!
  pom  {:project     'cljsjs/textures
@@ -17,14 +18,11 @@
 
 (deftask package []
   (comp
-    #_(download :url "https://github.com/riccardoscalco/textures/archive/master.zip"
-              :checksum "84A1B1D175D8407C7B110DFDD40F537E" ;;sha1
-              :unzip true)
-    (download :url "https://raw.githubusercontent.com/riccardoscalco/textures/master/textures.js"
-              :checksum "880132a6e85afa07a3001350d3b287ef")
-    (sift :move {#"textures.js" "cljsjs/textures/development/textures.inc.js"
-                 #_#"textures.min.js" #_"cljsjs/textures/production/textures.min.inc.js"})
-    (sift :include #{#"^cljsjs"})
-    (deps-cljs :name "cljsjs.textures")
-    (pom)
-    (jar)))
+   (download :url "https://raw.githubusercontent.com/riccardoscalco/textures/83094475a6cc6f58e6d0755cb0e7720f156ec65a/dist/textures.js"
+             :checksum "14ed87ddddfe4f6e56b9f715f8d11ca6")
+   (sift :move {#"textures.js" "cljsjs/textures/development/textures.inc.js"})
+   (sift :include #{#"^cljsjs"})
+   (deps-cljs :name "cljsjs.textures"
+              :requires ["cljsjs.d3"])
+   (pom)
+   (jar)))


### PR DESCRIPTION

Added dependency on d3 to remove requirement for external include and better integration with advanced compile. Lock version of the source js file to ensure build reproducibility.