### PR TITLE
[react-number-format] Add checksums

### DIFF
--- a/react-number-format/boot-cljsjs-checksums.edn
+++ b/react-number-format/boot-cljsjs-checksums.edn
@@ -1,0 +1,4 @@
+{"cljsjs/react-number-format/development/react-number-format.inc.js"
+ "C96F859D9420072767247114723D5B08",
+ "cljsjs/react-number-format/production/react-number-format.min.inc.js"
+ "805652F355DC382D91B5F7B423B78A55"}

--- a/react-number-format/build.boot
+++ b/react-number-format/build.boot
@@ -36,4 +36,5 @@
     (deps-cljs :name "cljsjs.react-number-format"
                :requires ["cljsjs.react"])
     (pom)
-    (jar)))
+    (jar)
+    (validate)))


### PR DESCRIPTION
I don't think the version number needs to be bumped. Just putting this in so that it's there for the next time the library version is bumped.