### PR TITLE
[react-sortable-hoc] Update to version 0.8.2 & Update extern definitions to align with new version

### DIFF
--- a/react-sortable-hoc/boot-cljsjs-checksums.edn
+++ b/react-sortable-hoc/boot-cljsjs-checksums.edn
@@ -1,4 +1,4 @@
 {"cljsjs/react-sortable-hoc/development/react-sortable-hoc.inc.js"
- "30BE57A5E24D5B1CBA011125CF0A0D75",
+ "D841F4132ECFD488138949AFB89C7EBA",
  "cljsjs/react-sortable-hoc/production/react-sortable-hoc.min.inc.js"
- "AA26059F3E6AC781DB3B37EA7F660F82"}
+ "CDAB1665C4C74B165434E7AE60007258"}

--- a/react-sortable-hoc/build.boot
+++ b/react-sortable-hoc/build.boot
@@ -6,7 +6,7 @@
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
-(def +lib-version+ "0.6.8")
+(def +lib-version+ "0.8.2")
 (def +version+ (str +lib-version+ "-0"))
 
 (task-options!

--- a/react-sortable-hoc/resources/cljsjs/react-sortable-hoc/common/react-sortable-hoc.ext.js
+++ b/react-sortable-hoc/resources/cljsjs/react-sortable-hoc/common/react-sortable-hoc.ext.js
@@ -1,5 +1,9 @@
 var SortableHOC = {};
 
-SortableHOC.SortableElement = function() {};
-
-SortableHOC.SortableContainer = function() {};
+SortableHOC.SortableContainer = function () {};
+SortableHOC.SortableElement   = function () {};
+SortableHOC.SortableHandle    = function () {};
+SortableHOC.arrayMove         = function () {};
+SortableHOC.sortableContainer = function () {};
+SortableHOC.sortableElement   = function () {};
+SortableHOC.sortableHandle    = function () {};


### PR DESCRIPTION
* Update to latest version as of 8/10/2018. 
* Generated & added missing extern definitions (based off of jmmk/javascript-externs-generator result)