### PR TITLE
Initial import of react-test-renderer-shallow.

### DIFF
--- a/react-test-renderer-shallow/README.md
+++ b/react-test-renderer-shallow/README.md
@@ -1,0 +1,18 @@
+# cljsjs/react-test-renderer-shallow
+
+[](dependency)
+```clojure
+[cljsjs/react-test-renderer-shallow "16.4.1-0"] ;; latest release
+```
+[](/dependency)
+
+This jar comes with `deps.cljs` as used by the [Foreign Libs][flibs] feature
+of the ClojureScript compiler. After adding the above dependency to your project
+you can require the packaged library like so:
+
+```clojure
+(ns application.core
+  (:require cljsjs.react.test-renderer.shallow))
+```
+
+[flibs]: https://clojurescript.org/reference/packaging-foreign-deps

--- a/react-test-renderer-shallow/boot-cljsjs-checksums.edn
+++ b/react-test-renderer-shallow/boot-cljsjs-checksums.edn
@@ -1,0 +1,4 @@
+{"cljsjs/react-test-renderer-shallow/development/react-test-renderer-shallow.inc.js"
+ "05611E18CB1BA10E8DC4ED93E63581B3",
+ "cljsjs/react-test-renderer-shallow/production/react-test-renderer-shallow.min.inc.js"
+ "025A9B709E17C41A12F20CE11BAE30CF"}

--- a/react-test-renderer-shallow/build.boot
+++ b/react-test-renderer-shallow/build.boot
@@ -1,0 +1,30 @@
+(set-env!
+  :resource-paths #{"resources"}
+  :dependencies '[[cljsjs/boot-cljsjs "0.10.0" :scope "test"]
+                  [cljsjs/react "16.4.1-0"]])
+
+(require '[cljsjs.boot-cljsjs.packaging :refer :all])
+
+  (def +lib-version+ "16.4.1")
+(def +version+ (str +lib-version+ "-0"))
+
+(task-options!
+ pom  {:project     'cljsjs/react-test-renderer-shallow
+       :version     +version+
+       :description "The React shallow renderer"
+       :url         "http://facebook.github.io/react/"
+       :scm         {:url "https://github.com/cljsjs/packages"}
+       :license     {"MIT" "http://opensource.org/licenses/MIT"}})
+
+(deftask package []
+  (comp
+    (download :url (format "https://unpkg.com/react-test-renderer@%s/umd/react-test-renderer-shallow.development.js" +lib-version+)
+              :target "cljsjs/react-test-renderer-shallow/development/react-test-renderer-shallow.inc.js")
+    (download :url (format "https://unpkg.com/react-test-renderer@%s/umd/react-test-renderer-shallow.production.min.js" +lib-version+)
+              :target "cljsjs/react-test-renderer-shallow/production/react-test-renderer-shallow.min.inc.js")
+    (deps-cljs :provides ["react-test-renderer/shallow" "cljsjs.react.test-renderer.shallow"]
+               :requires ["react"]
+               :global-exports '{react-test-renderer-shallow ShallowRenderer})
+    (pom)
+    (jar)
+    (validate)))

--- a/react-test-renderer-shallow/resources/cljsjs/react-test-renderer-shallow/common/react-test-renderer-shallow.ext.js
+++ b/react-test-renderer-shallow/resources/cljsjs/react-test-renderer-shallow/common/react-test-renderer-shallow.ext.js
@@ -1,0 +1,16 @@
+/**
+ * @type {!Object}
+ * @const
+ * @suppress {const|duplicate}
+ */
+var ShallowRenderer = function() {}
+
+/**
+ * @return {Object}
+ */
+ShallowRenderer.prototype.render = function() {}
+
+/**
+ * @return {Object}
+ */
+ShallowRenderer.prototype.getRenderOutput = function() {}


### PR DESCRIPTION
SSIA: Another package spun out of React; needed this for Reacl.