### PR TITLE
[iota-mam] fix externs name

### DIFF
--- a/iota-mam/build.boot
+++ b/iota-mam/build.boot
@@ -5,7 +5,7 @@
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
 (def +lib-version+ "0.0.1")
-(def +version+ (str +lib-version+ "-0"))
+(def +version+ (str +lib-version+ "-1"))
 
 (task-options!
  pom {:project     'cljsjs/iota-mam


### PR DESCRIPTION
It conflicted with iota.js:

when building a project that uses both iota and iota-mam with advanced compilation the extern files conflicted. The reason was that iota-mam had an externs file `iota/iota.ext.js` and that is the same as the one for iota. This commit changes the iota-mam externs file to `iota-mam/iota-mam.ext.js`.