### PR TITLE
[codemirror] Add toTextArea to extern

### DIFF
--- a/codemirror/build.boot
+++ b/codemirror/build.boot
@@ -6,7 +6,7 @@
 
 (def +lib-version+ "5.40.2")
 
-(def +version+ (str +lib-version+ "-0"))
+(def +version+ (str +lib-version+ "-1"))
 
 (task-options!
   pom  {:project     'cljsjs/codemirror

--- a/codemirror/resources/cljsjs/codemirror/common/codemirror.ext.js
+++ b/codemirror/resources/cljsjs/codemirror/common/codemirror.ext.js
@@ -36,6 +36,7 @@ var CodeMirror = {
   "isModifierKey": function () {},
   "keyName": function () {},
   "fromTextArea": function () {},
+  "toTextArea": function () {},
   "StringStream": function () {},
   "TextMarker": function () {},
   "SharedTextMarker": function () {},


### PR DESCRIPTION
After reading the guidelines a couple of times I think this PR is fine. I apologize in advanced if it is not. It would seem that this package is not using the latest `boot-cljsjs` since no checksum file was produced by `boot package install`.

I've tested the changes and when using advanced compilation, `toTextArea` can be used without problem.