### PR TITLE
[vega] update to latest release

### DIFF
--- a/vega/README.md
+++ b/vega/README.md
@@ -2,7 +2,7 @@
 
 [](dependency)
 ```clojure
-[cljsjs/vega "4.3.0-0"] ;; latest release
+[cljsjs/vega "4.4.0-0"] ;; latest release
 ```
 [](/dependency)
 

--- a/vega/boot-cljsjs-checksums.edn
+++ b/vega/boot-cljsjs-checksums.edn
@@ -1,2 +1,2 @@
-{"cljsjs/development/vega.inc.js" "8386C176FA154BB3A7017C5132F42C67",
- "cljsjs/production/vega.min.inc.js" "48955EE0BA7AB0A5D2E59F6A471EA178"}
+{"cljsjs/development/vega.inc.js" "2B16C8690FE941B0D7EDF5CC5D58562E",
+ "cljsjs/production/vega.min.inc.js" "2F25DE6B2BA30B02F110C44988899FC0"}

--- a/vega/build.boot
+++ b/vega/build.boot
@@ -4,7 +4,7 @@
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
-(def +lib-version+ "4.3.0")
+(def +lib-version+ "4.4.0")
 (def +version+ (str +lib-version+ "-0"))
 
 (task-options!

--- a/vega/resources/cljsjs/vega/common/vega.ext.js
+++ b/vega/resources/cljsjs/vega/common/vega.ext.js
@@ -196,6 +196,13 @@ var vega = {
   "font": function () {},
   "fontFamily": function () {},
   "fontSize": function () {},
+  "format": {
+    "csv": function () {},
+    "dsv": function () {},
+    "json": function () {},
+    "topojson": function () {},
+    "tsv": function () {}
+  },
   "formatLocale": function () {},
   "formats": function () {},
   "id": {


### PR DESCRIPTION
Update to Vega 4.4.0 in order to update vega-* packages to their latest