### PR TITLE
[enzyme] Update to version 3.8.0 with enzyme-adapter-react-16

### DIFF
--- a/enzyme/README.md
+++ b/enzyme/README.md
@@ -4,7 +4,7 @@ https://github.com/airbnb/enzyme
 
 [](dependency)
 ```clojure
-[cljsjs/enzyme "3.0.0"] ;; latest release
+[cljsjs/enzyme "3.8.0"] ;; latest release
 ```
 [](/dependency)
 
@@ -16,3 +16,6 @@ you can require the packaged library like so:
 (ns application.core
   (:require cljsjs.enzyme))
 ```
+
+Note that this package is configured with the `enzyme-adapter-react-16` adapter - compatible with react `^16.4.0`.
+If other enzyme adapter versions are required, this package may need to be restructured.

--- a/enzyme/resources/build/helper.js
+++ b/enzyme/resources/build/helper.js
@@ -1,5 +1,5 @@
 import * as enzyme from 'enzyme';
-import Adapter from 'enzyme-adapter-react-15';
+import Adapter from 'enzyme-adapter-react-16';
 
 enzyme.configure({ adapter: new Adapter() });
 


### PR DESCRIPTION
This PR updates enzyme to 3.8.0. It builds a custom package with enzyme-adapter-react-16.

If other enzyme adapter versions are required, this package will need to be split / restructured.