### PR TITLE
[elkjs] Add elkjs - eclipse layout kernel

### DIFF
--- a/elkjs/README.md
+++ b/elkjs/README.md
@@ -1,0 +1,23 @@
+# cljsjs/elkjs
+
+[](dependency)
+```clojure
+[cljsjs/elkjs "0.3.0-0"] ;; latest release
+```
+[](/dependency)
+
+After adding the above dependency to your project you can require the packaged library like so:
+
+```clojure
+(ns application.core
+  (:require cljsjs.elkjs))
+```
+
+Sample use:
+
+```clojure
+(defn compute-layout [graph options success error]
+     (->  (.layout (js/ELK.) (clj->js graph) (clj->js (or options {})))
+          (.then #(success (js->clj % :keywordize-keys true)))
+          (.catch #(error (js->clj % :keywordize-keys true)))))
+```

--- a/elkjs/boot-cljsjs-checksums.edn
+++ b/elkjs/boot-cljsjs-checksums.edn
@@ -1,0 +1,1 @@
+{"cljsjs/production/elk.min.inc.js" "75CAEECDDFF120385BB198C7785C0EDF"}

--- a/elkjs/build.boot
+++ b/elkjs/build.boot
@@ -1,0 +1,27 @@
+(set-env!
+  :resource-paths #{"resources"}
+  :dependencies '[[cljsjs/boot-cljsjs "0.8.2" :scope "test"]])
+
+(require '[cljsjs.boot-cljsjs.packaging :refer :all])
+
+(def +lib-version+ "0.3.0")
+(def +version+ (str +lib-version+ "-0"))
+
+(task-options!
+  pom {:project     'cljsjs/elkjs
+       :version     +version+
+       :description "The Eclipse Layout Kernel (ELK) implements an infrastructure to connect diagram editors or viewers to automatic layout algorithms. This library takes the layout-relevant part of ELK and makes it available to the JavaScript world."
+       :url         "https://github.com/OpenKieler/elkjs"
+       :scm         {:url "https://github.com/OpenKieler/elkjs"}
+       :license     {"EPL" "http://www.eclipse.org/legal/epl-v10.html"}})
+
+(deftask package []
+  (comp
+   (download :url (format "https://unpkg.com/elkjs@%s/lib/elk.bundled.js" +lib-version+))
+    (sift :move {#"elk.bundled.js" "cljsjs/development/elk.inc.js"})
+    (minify :in "cljsjs/development/elk.inc.js"
+            :out "cljsjs/production/elk.min.inc.js")
+    (sift :include #{#"^cljsjs"})
+    (deps-cljs :name "cljsjs.elkjs")
+    (pom)
+    (jar)))

--- a/elkjs/resources/cljsjs/elkjs/common/elkjs.ext.js
+++ b/elkjs/resources/cljsjs/elkjs/common/elkjs.ext.js
@@ -1,0 +1,9 @@
+/**
+ * @fileoverview Closure Compiler externs for Kieler KlayJS 0.3.2.
+ * @see http://rtsys.informatik.uni-kiel.de/confluence/display/KIELER/KIELER+Layout
+ * @externs
+ */
+
+var ELK = {
+    layout: function(graph,options) {}
+};


### PR DESCRIPTION
Adding elkjs, the successor for klayjs, which already exists in this repo.
