### PR TITLE
[Phaser] Updates phaser to 3.16.2 release.

### DIFF
--- a/phaser/boot-cljsjs-checksums.edn
+++ b/phaser/boot-cljsjs-checksums.edn
@@ -1,0 +1,4 @@
+{"cljsjs/phaser/development/phaser.inc.js"
+ "FF654E3737B1BDE293FD95D9E7949393",
+ "cljsjs/phaser/production/phaser.min.inc.js"
+ "7544FE2DA5496909A0E256C48F403651"}

--- a/phaser/build.boot
+++ b/phaser/build.boot
@@ -4,11 +4,10 @@
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
-(def +lib-version+ "2.6.1")
+(def +lib-version+ "3.16.2")
 (def +version+ (str +lib-version+ "-0"))
 
 (task-options!
- push {:ensure-clean false}
  pom  {:project     'cljsjs/phaser
        :version     +version+
        :description "Phaser is a fast, free, and fun open source framework for Canvas and WebGL powered browser games."
@@ -18,16 +17,12 @@
 
 (deftask package []
   (comp
-   (download :url (format "http://cdn.jsdelivr.net/phaser/%s/phaser.zip" +lib-version+)
-             :checksum "82319568fc64f2f2d3a6d75eeb9f72d5"
-             :unzip true)
-   (sift :move {#"^phaser\.js$"
-                "cljsjs/phaser/development/phaser.inc.js"
-                #"^phaser\.map$"
-                "cljsjs/phaser/development/phaser.map"
-                #"^phaser\.min\.js$"
-                "cljsjs/phaser/production/phaser.min.inc.js"})
+   (download :url (format "https://cdn.jsdelivr.net/npm/phaser@%s/dist/phaser.js" +lib-version+)
+             :target "cljsjs/phaser/development/phaser.inc.js")
+   (download :url (format "https://cdn.jsdelivr.net/npm/phaser@%s/dist/phaser.min.js" +lib-version+)
+             :target "cljsjs/phaser/production/phaser.min.inc.js")
    (sift :include #{#"^cljsjs"})
    (deps-cljs :name "cljsjs.phaser")
    (pom)
-   (jar)))
+   (jar)
+   (validate-checksums)))


### PR DESCRIPTION
* Updates the cdn uri as the scheme doesnt work for the latest release.
* Updates phaser to latest release 3.16.2
* Adds checksums edn file.
* Adds validates-checksum to build.boot
* Removes `map` file from deftask as latest phaser does not ship with a map file.