### PR TITLE
[libphonenumber] Update to 8.10.8

### DIFF
--- a/libphonenumber/build.boot
+++ b/libphonenumber/build.boot
@@ -4,8 +4,8 @@
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
-(def +lib-version+ "8.4.1")
-(def +version+ (str +lib-version+ "-2"))
+(def +lib-version+ "8.10.8")
+(def +version+ (str +lib-version+ "-0"))
 
 (task-options!
  pom  {:project     'cljsjs/libphonenumber
@@ -18,7 +18,7 @@
 (deftask package []
   (comp
     (download :url (format "https://github.com/googlei18n/libphonenumber/archive/v%s.zip" +lib-version+)
-              :checksum "450DD8CE0823BCE4B00673808CD8468D"
+              :checksum "584649705B795CCFBD9C554062F542B1"
               :unzip true)
     (show :fileset true)
     (sift :move {#"^libphonenumber-[\d\.]*/javascript/i18n/phonenumbers/" "cljsjs/libphonenumber/development/i18n/"})


### PR DESCRIPTION
I couldn't figure out how to get the boot scripts to create a proper checksum file for this package, but I manually downloaded the archive and created an updated MD5 for it.

I tested the resulting build in my downstream app and it appears to be OK.