### PR TITLE
[vega-embed, vega-tooltip] -> versions 4.0.0-0, 0.17.0-0 respectively

### DIFF
--- a/vega-embed/build.boot
+++ b/vega-embed/build.boot
@@ -1,12 +1,12 @@
 (set-env!
   :resource-paths #{"resources"}
   :dependencies '[[cljsjs/boot-cljsjs "0.10.3" :scope "test"]
-                  [cljsjs/vega "5.3.1-0"]
-                  [cljsjs/vega-lite "3.0.0-rc16-0"]])
+                  [cljsjs/vega "5.3.2-0"]
+                  [cljsjs/vega-lite "3.0.2-0"]])
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
-  (def +lib-version+ "4.0.0-rc1")
+  (def +lib-version+ "4.0.0")
 (def +version+ (str +lib-version+ "-0"))
 
 (task-options!
@@ -21,10 +21,10 @@
   (comp
     (download
      :url (format "https://unpkg.com/vega-embed@%s/build/vega-embed.js" +lib-version+)
-     :checksum "664c68e07c1b9ac987b1f16848c5ccff")
+     :checksum "a1de4b3de6c3d040c54bd180bdeeef0b")
     (download
      :url (format "https://unpkg.com/vega-embed@%s/build/vega-embed.min.js" +lib-version+)
-     :checksum "f6d8f9bc6416b5080c3cabc10bfc4bdc")
+     :checksum "ceaef0a57f250b6012cf1891db001fa6")
     (sift :move {#".*vega-embed\.js$"      "cljsjs/development/vega-embed.inc.js"})
     (sift :move {#".*vega-embed\.min\.js$" "cljsjs/production/vega-embed.min.inc.js"})
     (sift :include #{#"^cljsjs"})

--- a/vega-lite/build.boot
+++ b/vega-lite/build.boot
@@ -1,11 +1,11 @@
 (set-env!
   :resource-paths #{"resources"}
   :dependencies '[[cljsjs/boot-cljsjs "0.10.3" :scope "test"]
-                  [cljsjs/vega "5.3.1-0"]])
+                  [cljsjs/vega "5.3.2-0"]])
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
-(def +lib-version+ "3.0.0-rc16")
+(def +lib-version+ "3.0.2")
 (def +version+ (str +lib-version+ "-0"))
 
 (task-options!
@@ -21,7 +21,7 @@
     (download
       :url (str "https://github.com/vega/vega-lite/archive/v" +lib-version+ ".zip")
       :unzip true
-      :checksum "8f8c2bafd585f560514eee1049a36127")
+      :checksum "d9a04619516aed0ded2f4c9d89aa2b05")
     (sift :move {(re-pattern (str "^vega-lite-" +lib-version+ "/build/vega-lite.js$")) "cljsjs/development/vega-lite.inc.js"
                  (re-pattern (str "^vega-lite-" +lib-version+ "/build/vega-lite.min.js$")) "cljsjs/production/vega-lite.min.inc.js"})
     (sift :include #{#"^cljsjs"})

--- a/vega-tooltip/build.boot
+++ b/vega-tooltip/build.boot
@@ -1,11 +1,11 @@
 (set-env!
   :resource-paths #{"resources"}
   :dependencies '[[cljsjs/boot-cljsjs "0.10.3" :scope "test"]
-                  [cljsjs/vega "5.3.1-0"]])
+                  [cljsjs/vega "5.3.2-0"]])
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
-(def +lib-version+ "0.16.0")
+(def +lib-version+ "0.17.0")
 
 (def +version+ (str +lib-version+ "-0"))
 
@@ -21,10 +21,10 @@
   (comp
     (download
      :url (format "https://unpkg.com/vega-tooltip@%s/build/vega-tooltip.js" +lib-version+)
-     :checksum "7b84b36c32d6c89689181d58b59e5a9b")
+     :checksum "695fc4d62ec3016438a03abdf6d54de4")
     (download
      :url (format "https://unpkg.com/vega-tooltip@%s/build/vega-tooltip.min.js" +lib-version+)
-     :checksum "6130c3ebe65b2def55ea1b9213d945a4")
+     :checksum "a8bf5931845f3c6ed620b52c965df6b1")
     (sift :move {#".*vega-tooltip\.js$"      "cljsjs/vega-tooltip/development/vega-tooltip.inc.js"})
     (sift :move {#".*vega-tooltip\.min\.js$" "cljsjs/vega-tooltip/production/vega-tooltip.min.inc.js"})
     (sift :include #{#"^cljsjs"})

--- a/vega/boot-cljsjs-checksums.edn
+++ b/vega/boot-cljsjs-checksums.edn
@@ -1,2 +1,2 @@
-{"cljsjs/development/vega.inc.js" "3476C1A0E3760C07E24E82C8023124E3",
- "cljsjs/production/vega.min.inc.js" "41748BD2AA71E63E29307965FBC21F26"}
+{"cljsjs/development/vega.inc.js" "A830568F8B8AE48C0A7A884E14D751D8",
+ "cljsjs/production/vega.min.inc.js" "C6F9ECFD22214D3413E3454D1075987D"}

--- a/vega/build.boot
+++ b/vega/build.boot
@@ -4,7 +4,7 @@
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
-(def +lib-version+ "5.3.1")
+(def +lib-version+ "5.3.2")
 (def +version+ (str +lib-version+ "-0"))
 
 (task-options!
@@ -18,10 +18,10 @@
   (comp
     (download
      :url (format "https://unpkg.com/vega@%s/build/vega.js" +lib-version+)
-     :checksum "3476c1a0e3760c07e24e82c8023124e3")
+     :checksum "a830568f8b8ae48c0a7a884e14d751d8")
     (download
      :url (format "https://unpkg.com/vega@%s/build/vega.min.js" +lib-version+)
-     :checksum "41748bd2aa71e63e29307965fbc21f26")
+     :checksum "c6f9ecfd22214d3413e3454d1075987d")
    (sift :move {(re-pattern "^vega.js$") "cljsjs/development/vega.inc.js"
                 (re-pattern "^vega.min.js$") "cljsjs/production/vega.min.inc.js"})
    (sift :include #{#"^cljsjs"})


### PR DESCRIPTION
built against vega 5.3.2-0 and vega-lite 3.0.0-0