### PR TITLE
[react-test-renderer] Fix exported object from TestRenderer to ReactT…

### DIFF
--- a/react-test-renderer/build.boot
+++ b/react-test-renderer/build.boot
@@ -6,7 +6,7 @@
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
   (def +lib-version+ "16.4.1")
-(def +version+ (str +lib-version+ "-0"))
+(def +version+ (str +lib-version+ "-1"))
 
 (task-options!
  pom  {:project     'cljsjs/react-test-renderer
@@ -24,7 +24,7 @@
               :target "cljsjs/react-test-renderer/production/react-test-renderer.min.inc.js")
     (deps-cljs :provides ["react-test-renderer" "cljsjs.react.test-renderer"]
                :requires ["react"]
-               :global-exports '{react-test-renderer TestRenderer})
+               :global-exports '{react-test-renderer ReactTestRenderer})
     (pom)
     (jar)
     (validate)))


### PR DESCRIPTION
The global-exports specification was wrong, preventing named imports of the package. (https://github.com/facebook/react/blob/v16.4.1/packages/react-test-renderer/index.js)