### PR TITLE
[react-shallow-test-renderer] Fix exported object and externs from Sh…

### DIFF
--- a/react-test-renderer-shallow/build.boot
+++ b/react-test-renderer-shallow/build.boot
@@ -6,7 +6,7 @@
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
   (def +lib-version+ "16.4.1")
-(def +version+ (str +lib-version+ "-0"))
+(def +version+ (str +lib-version+ "-1"))
 
 (task-options!
  pom  {:project     'cljsjs/react-test-renderer-shallow
@@ -24,7 +24,7 @@
               :target "cljsjs/react-test-renderer-shallow/production/react-test-renderer-shallow.min.inc.js")
     (deps-cljs :provides ["react-test-renderer/shallow" "cljsjs.react.test-renderer.shallow"]
                :requires ["react"]
-               :global-exports '{react-test-renderer-shallow ShallowRenderer})
+               :global-exports '{react-test-renderer-shallow ReactShallowRenderer})
     (pom)
     (jar)
     (validate)))

--- a/react-test-renderer-shallow/resources/cljsjs/react-test-renderer-shallow/common/react-test-renderer-shallow.ext.js
+++ b/react-test-renderer-shallow/resources/cljsjs/react-test-renderer-shallow/common/react-test-renderer-shallow.ext.js
@@ -3,14 +3,14 @@
  * @const
  * @suppress {const|duplicate}
  */
-var ShallowRenderer = function() {}
+var ReactShallowRenderer = function() {}
 
 /**
  * @return {Object}
  */
-ShallowRenderer.prototype.render = function() {}
+ReactShallowRenderer.prototype.render = function() {}
 
 /**
  * @return {Object}
  */
-ShallowRenderer.prototype.getRenderOutput = function() {}
+ReactShallowRenderer.prototype.getRenderOutput = function() {}


### PR DESCRIPTION
The global-exports specification (and also the externs) were wrong, preventing a named import of the package. (also see https://github.com/facebook/react/blob/v16.4.1/packages/react-test-renderer/shallow.js)