### PR TITLE
[oidc-client] More externs: User object

### DIFF
--- a/oidc-client/README.md
+++ b/oidc-client/README.md
@@ -1,7 +1,7 @@
 # cljsjs/oidc-client
 
 ```clojure
-[cljsjs/oidc-client "1.7.1-0"] ;; latest release
+[cljsjs/oidc-client "1.7.1-1"] ;; latest release
 ```
 
 This jar comes with `deps.cljs` as used by the [Foreign Libs][flibs] feature

--- a/oidc-client/build.boot
+++ b/oidc-client/build.boot
@@ -5,7 +5,7 @@
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
 (def +lib-version+ "1.7.1")
-(def +version+ (str +lib-version+ "-0"))
+(def +version+ (str +lib-version+ "-1"))
 
 (def unpkg-dist-url (str "https://unpkg.com/oidc-client@" +lib-version+ "/dist"))
 

--- a/oidc-client/resources/cljsjs/oidc-client/common/oidc-client.ext.js
+++ b/oidc-client/resources/cljsjs/oidc-client/common/oidc-client.ext.js
@@ -158,3 +158,26 @@ UserManagerEvents.prototype = {
 
 /** @type {UserManagerEvents} */
 Oidc.UserManager.prototype.events;
+
+/** @record */
+function User() {};
+
+User.prototype = {
+    "id_token": function () {},
+    "session_state": function () {},
+    "access_token": function () {},
+    "refresh_token": function () {},
+    "token_type": function () {},
+    "scope": function () {},
+    "profile": function () {},
+    "expires_at": function () {},
+    "state": function () {},
+    "expires_in": function () {},
+    "expired": function () {},
+    "scopes": function () {},
+    "toStorageString": function () {},
+    "fromStorageString": function () {}
+};
+
+/** @type {User} */
+Oidc.UserManager.prototype.getUser;


### PR DESCRIPTION
This PR adds externs for the User object, which is [described in the documentation](https://github.com/IdentityModel/oidc-client-js/wiki#user) (and can thus be considered a public API) but was not yet covered by the externs file.