### PR TITLE
[simplebar] Initial SimpleBar CLJSJS Package

### DIFF
--- a/simplebar/README.md
+++ b/simplebar/README.md
@@ -1,0 +1,18 @@
+# cljsjs/simplebar
+
+[](dependency)
+```clojure
+[cljsjs/simplebar "5.0.7-0"]
+```
+[](/dependency)
+
+This jar comes with `deps.cljs` as used by the [Foreign Libs][flibs] feature
+of the ClojureScript compiler. After adding the above dependency to your project
+you can require the packaged library like so:
+
+```clojure
+(ns application.core
+  (:require cljsjs.simplebar))
+```
+
+[flibs]: https://clojurescript.org/reference/packaging-foreign-deps

--- a/simplebar/boot-cljsjs-checksums.edn
+++ b/simplebar/boot-cljsjs-checksums.edn
@@ -1,0 +1,2 @@
+{"cljsjs/simplebar/development/simplebar.inc.js"
+ "AEFF7E581527019E7B67FF42DF3924D3"}

--- a/simplebar/build.boot
+++ b/simplebar/build.boot
@@ -1,0 +1,37 @@
+(set-env!
+  :resource-paths #{"resources"}
+  :dependencies '[[cljsjs/boot-cljsjs "0.10.4" :scope "test"]])
+
+(require '[cljsjs.boot-cljsjs.packaging :refer :all])
+
+(def +lib-version+ "5.0.7")
+(def +version+ (str +lib-version+ "-0"))
+
+(task-options!
+ pom  {:project     'cljsjs/simplebar
+       :version     +version+
+       :description "Custom scrollbars vanilla javascript library with native scroll, cross-browser."
+       :url         "http://grsmto.github.io/simplebar/"
+       :scm         {:url "https://github.com/Grsmto/simplebar"}
+       :license     {"MIT" "http://opensource.org/licenses/MIT"}})
+
+
+(deftask package []
+  (comp
+
+   ;; Development Files
+   (download :url       (format "https://unpkg.com/simplebar@%s/dist/simplebar.css" +lib-version+)
+             :target    "cljsjs/simplebar/development/simplebar.inc.css")
+   (download :url       (format "https://unpkg.com/simplebar@%s/dist/simplebar.js" +lib-version+)
+             :target    "cljsjs/simplebar/development/simplebar.inc.js")
+
+   ;; Production Files
+   (download :url       (format "https://unpkg.com/simplebar@%s/dist/simplebar.min.css" +lib-version+)
+             :target    "cljsjs/simplebar/production/simplebar.inc.min.css")
+   (download :url       (format "https://unpkg.com/simplebar@%s/dist/simplebar.min.js" +lib-version+)
+             :target    "cljsjs/simplebar/production/simplebar.inc.min.js")
+
+   (deps-cljs :name     "cljsjs.simplebar")
+   (pom)
+   (jar)
+   (validate)))

--- a/simplebar/resources/cljsjs/simplebar/common/simplebar.ext.js
+++ b/simplebar/resources/cljsjs/simplebar/common/simplebar.ext.js
@@ -1,0 +1,62 @@
+/**
+ * @fileoverview Simplebar Externs File
+ * @externs
+ */
+
+
+/**
+ * Main Entry-point
+ * @constructor
+ */
+var SimpleBar = function(element, options){};
+
+
+/**
+ * Parameters
+ */
+
+SimpleBar.defaultOptions = {};
+SimpleBar.instances = {};
+
+
+/**
+ * Functions
+ */
+
+SimpleBar.getOffset = function(el){};
+SimpleBar.getOptions = function(obj){};
+SimpleBar.getRtlHelpers = function(){};
+SimpleBar.handleMutations = function(mutations){};
+SimpleBar.initDOMLoadedElements = function(){};
+SimpleBar.initHtmlApi = function(){};
+SimpleBar.removeObserver = function(){};
+
+
+/**
+ * Prototype Functions
+ */
+
+SimpleBar.prototype.findChild = function(el, query){};
+SimpleBar.prototype.getContentElement = function(){};
+SimpleBar.prototype.getScrollElement = function(){};
+SimpleBar.prototype.getScrollbarSize = function(axis){};
+SimpleBar.prototype.getScrollbarWidth = function(){};
+SimpleBar.prototype.hideNativeScrollbar = function(){};
+SimpleBar.prototype.init = function(){};
+SimpleBar.prototype.initDOM = function(){};
+SimpleBar.prototype.initListeners = function(){};
+SimpleBar.prototype.isWithinBounds = function(bbox){};
+SimpleBar.prototype.onDragStart = function(e, axis){};
+SimpleBar.prototype.onMouseLeaveForAxis = function(axis){};
+SimpleBar.prototype.onMouseMoveForAxis = function(axis){};
+SimpleBar.prototype.onTrackClick = function(e, axis){};
+SimpleBar.prototype.positionScrollbar = function(axis){};
+SimpleBar.prototype.recalculate = function(){};
+SimpleBar.prototype.removeListeners = function(){};
+SimpleBar.prototype.showScrollbar = function(axis){};
+SimpleBar.prototype.toggleTrackVisibility = function(axis){};
+SimpleBar.prototype.unMount = function(){};
+
+
+
+


### PR DESCRIPTION
This is the first packaging of simplebar, which provides
the ability to include custom scrollbars on elements.
Cross-browser support. Tested Locally.