### PR TITLE
[React] Add parameters to componentDidCatch

### DIFF
--- a/react/resources/cljsjs/react/common/react.ext.js
+++ b/react/resources/cljsjs/react/common/react.ext.js
@@ -248,7 +248,7 @@ React.Component.prototype.componentWillUnmount = function() {};
  * @param {Object} error
  * @param {Object} info
  */
-React.Component.prototype.componentDidCatch = function() {error, info};
+React.Component.prototype.componentDidCatch = function(error, info) {};
 
 /**
  * @protected

--- a/react/resources/cljsjs/react/common/react.ext.js
+++ b/react/resources/cljsjs/react/common/react.ext.js
@@ -245,8 +245,10 @@ React.Component.prototype.componentWillUnmount = function() {};
 
 /**
  * @protected
+ * @param {Object} error
+ * @param {Object} errorInfo
  */
-React.Component.prototype.componentDidCatch = function() {};
+React.Component.prototype.componentDidCatch = function() {error, errorInfo};
 
 /**
  * @protected

--- a/react/resources/cljsjs/react/common/react.ext.js
+++ b/react/resources/cljsjs/react/common/react.ext.js
@@ -246,9 +246,9 @@ React.Component.prototype.componentWillUnmount = function() {};
 /**
  * @protected
  * @param {Object} error
- * @param {Object} errorInfo
+ * @param {Object} info
  */
-React.Component.prototype.componentDidCatch = function() {error, errorInfo};
+React.Component.prototype.componentDidCatch = function() {error, info};
 
 /**
  * @protected


### PR DESCRIPTION
The new lifecycle method componentDidCatch() in React 16 receives two paramaters:
1. error
1. info

Add them to react.ext.js to match this condition.
Tested Locally.

References:

https://reactjs.org/docs/react-component.html#componentdidcatch
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L587