### PR TITLE
[react-stripe-elements] Add injected props in StripeProvider

### DIFF
--- a/react-stripe-elements/build.boot
+++ b/react-stripe-elements/build.boot
@@ -7,7 +7,7 @@
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
 (def +lib-version+ "5.0.1")
-(def +version+ (str +lib-version+ "-0"))
+(def +version+ (str +lib-version+ "-1"))
 
 (task-options!
  pom  {:project     'cljsjs/react-stripe-elements

--- a/react-stripe-elements/resources/cljsjs/react-stripe-elements/common/react-stripe-elements.ext.js
+++ b/react-stripe-elements/resources/cljsjs/react-stripe-elements/common/react-stripe-elements.ext.js
@@ -386,7 +386,16 @@ var ReactStripeElements = {
     "defaultProps": {
       "apiKey": {},
       "children": {},
-      "stripe": {}
+      "stripe": {
+        // Note that these are dynamically injected.
+        // They aren't picked up by externs generation and need to be manually preserved.
+        // https://github.com/stripe/react-stripe-elements/blob/v6.0.1/src/components/inject.js#L98-L108
+        "createToken": function () {},
+        "createSource": function () {},
+        "createPaymentMethod": function () {},
+        "handleCardPayment": function () {},
+        "handleCardSetup": function () {}
+      }
     },
     "propTypes": {
       "apiKey": {


### PR DESCRIPTION
Stripe Elements injects some props dynamically in a way that externs generation can't detect. We added them manually to the main externs file. Is there a better way to do this instead?

<!--
PR Checklist

Have you read either:
https://github.com/cljsjs/packages/wiki/Creating-Packages
https://github.com/cljsjs/packages/wiki/Updating-packages

Did you follow contribution guidelines:
https://github.com/cljsjs/packages/blob/master/CONTRIBUTING.md

Did you remember to run package script locally and commit
boot-cljsjs-checksum.edn file changes?

boot package install
-->