### PR TITLE
[sentry-browser] Upgrade lib version and checksums.

### DIFF
--- a/sentry-browser/README.md
+++ b/sentry-browser/README.md
@@ -2,7 +2,7 @@
 
 [](dependency)
 ```clojure
-[cljsjs/sentry-browser "5.10.2-0"] ;; latest release
+[cljsjs/sentry-browser "5.11.1-0"] ;; latest release
 ```
 [](/dependency)
 

--- a/sentry-browser/boot-cljsjs-checksums.edn
+++ b/sentry-browser/boot-cljsjs-checksums.edn
@@ -1,4 +1,4 @@
 {"cljsjs/sentry-browser/development/sentry-browser.inc.js"
- "525228939692F38FCFB9F1C5D5843BE4",
+ "1F28E804C09BF1AD1ACA5F4D8DE5D99A",
  "cljsjs/sentry-browser/production/sentry-browser.min.inc.js"
- "E93C9AA5D77B29C4FF7A58BDEFC9A0A0"}
+ "D65B0419180FAC8C7F1E3575E2F04D45"}

--- a/sentry-browser/build.boot
+++ b/sentry-browser/build.boot
@@ -4,7 +4,7 @@
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
-(def +lib-version+ "5.10.2")
+(def +lib-version+ "5.11.1")
 (def +version+ (str +lib-version+ "-0"))
 
 (task-options!

--- a/sentry-browser/resources/cljsjs/sentry-browser/common/sentry-browser.ext.js
+++ b/sentry-browser/resources/cljsjs/sentry-browser/common/sentry-browser.ext.js
@@ -7,7 +7,6 @@ var Sentry = {
   "Hub": function () {},
   "Integrations": {
     "Breadcrumbs": {
-      "addBreadcrumb": function () {},
       "id": {}
     },
     "FunctionToString": {
@@ -43,9 +42,6 @@ var Sentry = {
     "Log": {},
     "Warning": {},
     "fromString": function () {}
-  },
-  "Span": {
-    "fromTraceparent": function () {}
   },
   "Status": {
     "Failed": {},
@@ -87,27 +83,28 @@ var Sentry = {
   "wrap": function () {}
 };
 Sentry.BrowserClient.prototype = {
-  "_addIntegrations": function () {},
-  "_getBackend": function () {},
-  "_handleAsyncBeforeSend": function () {},
-  "_isClientProcessing": function () {},
-  "_isEnabled": function () {},
-  "_prepareEvent": function () {},
-  "_processEvent": function () {},
+  "an": function () {},
   "captureEvent": function () {},
   "captureException": function () {},
   "captureMessage": function () {},
   "close": function () {},
+  "cn": function () {},
   "constructor": function () {},
   "flush": function () {},
+  "fn": function () {},
   "getDsn": function () {},
   "getIntegration": function () {},
   "getIntegrations": function () {},
   "getOptions": function () {},
-  "showReportDialog": function () {}
+  "in": function () {},
+  "on": function () {},
+  "showReportDialog": function () {},
+  "sn": function () {},
+  "un": function () {}
 };
 Sentry.Hub.prototype = {
-  "_invokeClient": function () {},
+  "G": function () {},
+  "V": function () {},
   "addBreadcrumb": function () {},
   "bindClient": function () {},
   "captureEvent": function () {},
@@ -130,54 +127,58 @@ Sentry.Hub.prototype = {
   "setTag": function () {},
   "setTags": function () {},
   "setUser": function () {},
+  "startSpan": function () {},
   "traceHeaders": function () {},
   "withScope": function () {}
 };
 Sentry.Integrations.Breadcrumbs.prototype = {
-  "_instrumentConsole": function () {},
-  "_instrumentDOM": function () {},
-  "_instrumentFetch": function () {},
-  "_instrumentHistory": function () {},
-  "_instrumentXHR": function () {},
+  "Fn": function () {},
+  "Hn": function () {},
+  "Ln": function () {},
+  "Pn": function () {},
+  "qn": function () {},
   "setupOnce": function () {}
 };
 Sentry.Integrations.FunctionToString.prototype = {
   "setupOnce": function () {}
 };
 Sentry.Integrations.GlobalHandlers.prototype = {
-  "_eventFromGlobalHandler": function () {},
-  "_eventFromIncompleteRejection": function () {},
+  "Dn": function () {},
+  "Nn": function () {},
+  "On": function () {},
+  "Rn": function () {},
+  "Tn": function () {},
   "setupOnce": function () {}
 };
 Sentry.Integrations.InboundFilters.prototype = {
-  "_getEventFilterUrl": function () {},
-  "_getPossibleEventMessages": function () {},
-  "_isBlacklistedUrl": function () {},
-  "_isIgnoredError": function () {},
-  "_isSentryError": function () {},
-  "_isWhitelistedUrl": function () {},
-  "_mergeOptions": function () {},
-  "_shouldDropEvent": function () {},
-  "setupOnce": function () {}
+  "bn": function () {},
+  "dn": function () {},
+  "gn": function () {},
+  "ln": function () {},
+  "mn": function () {},
+  "pn": function () {},
+  "setupOnce": function () {},
+  "wn": function () {},
+  "yn": function () {}
 };
 Sentry.Integrations.LinkedErrors.prototype = {
-  "_handler": function () {},
-  "_walkErrorTree": function () {},
+  "Bn": function () {},
+  "Xn": function () {},
   "setupOnce": function () {}
 };
 Sentry.Integrations.TryCatch.prototype = {
-  "_wrapEventTarget": function () {},
-  "_wrapRAF": function () {},
-  "_wrapTimeFunction": function () {},
+  "An": function () {},
+  "Cn": function () {},
+  "Mn": function () {},
+  "Un": function () {},
   "setupOnce": function () {}
 };
 Sentry.Integrations.UserAgent.prototype = {
   "setupOnce": function () {}
 };
 Sentry.Scope.prototype = {
-  "_applyFingerprint": function () {},
-  "_notifyEventProcessors": function () {},
-  "_notifyScopeListeners": function () {},
+  "L": function () {},
+  "X": function () {},
   "addBreadcrumb": function () {},
   "addEventProcessor": function () {},
   "addScopeListener": function () {},
@@ -185,6 +186,7 @@ Sentry.Scope.prototype = {
   "clear": function () {},
   "clearBreadcrumbs": function () {},
   "getSpan": function () {},
+  "q": function () {},
   "setContext": function () {},
   "setExtra": function () {},
   "setExtras": function () {},
@@ -194,14 +196,7 @@ Sentry.Scope.prototype = {
   "setTag": function () {},
   "setTags": function () {},
   "setTransaction": function () {},
-  "setUser": function () {},
-  "startSpan": function () {}
-};
-Sentry.Span.prototype = {
-  "setParent": function () {},
-  "setSampled": function () {},
-  "toJSON": function () {},
-  "toTraceparent": function () {}
+  "setUser": function () {}
 };
 Sentry.Transports.BaseTransport.prototype = {
   "close": function () {},


### PR DESCRIPTION
Upgrade sentry-browser package to 5.11.1 (latest) version.

Externs created with clijs tool.