### PR TITLE
[react-test-renderer] Updated to 16.13.0

### DIFF
--- a/react-test-renderer/boot-cljsjs-checksums.edn
+++ b/react-test-renderer/boot-cljsjs-checksums.edn
@@ -1,4 +1,4 @@
 {"cljsjs/react-test-renderer/development/react-test-renderer.inc.js"
- "EDD80B71AE612B9E0039A350C4EFC91C",
+ "058FCA1CADF20CF6E39CAB9854E6054A",
  "cljsjs/react-test-renderer/production/react-test-renderer.min.inc.js"
- "52916A52BDD7581A4AF43B2E59E28C63"}
+ "DE7B07C5E7CD987F98EE55460BBF586D"}

--- a/react-test-renderer/build.boot
+++ b/react-test-renderer/build.boot
@@ -1,12 +1,12 @@
 (set-env!
   :resource-paths #{"resources"}
   :dependencies '[[cljsjs/boot-cljsjs "0.10.5" :scope "test"]
-                  [cljsjs/react "16.4.1-0"]])
+                  [cljsjs/react "16.13.0-0"]])
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
-  (def +lib-version+ "16.4.1")
-(def +version+ (str +lib-version+ "-1"))
+  (def +lib-version+ "16.13.0")
+(def +version+ (str +lib-version+ "-0"))
 
 (task-options!
  pom  {:project     'cljsjs/react-test-renderer


### PR DESCRIPTION
Updated react-test-renderer package to same version as cljsjs/react.
