### PR TITLE
[react-test-renderer-shallow] Updated to 16.13.0

### DIFF
--- a/react-test-renderer-shallow/boot-cljsjs-checksums.edn
+++ b/react-test-renderer-shallow/boot-cljsjs-checksums.edn
@@ -1,4 +1,4 @@
 {"cljsjs/react-test-renderer-shallow/development/react-test-renderer-shallow.inc.js"
- "05611E18CB1BA10E8DC4ED93E63581B3",
+ "FCD8F55B357CFEF3ABEC9E32E50F1028",
  "cljsjs/react-test-renderer-shallow/production/react-test-renderer-shallow.min.inc.js"
- "025A9B709E17C41A12F20CE11BAE30CF"}
+ "8C61C0C725432C18E6C09450DDC1B8FC"}

--- a/react-test-renderer-shallow/build.boot
+++ b/react-test-renderer-shallow/build.boot
@@ -1,12 +1,12 @@
 (set-env!
   :resource-paths #{"resources"}
   :dependencies '[[cljsjs/boot-cljsjs "0.10.5" :scope "test"]
-                  [cljsjs/react "16.4.1-0"]])
+                  [cljsjs/react "16.13.0-0"]])
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
-  (def +lib-version+ "16.4.1")
-(def +version+ (str +lib-version+ "-1"))
+  (def +lib-version+ "16.13.0")
+(def +version+ (str +lib-version+ "-0"))
 
 (task-options!
  pom  {:project     'cljsjs/react-test-renderer-shallow


### PR DESCRIPTION
Updated react-test-renderer-shallow to same version as cljsjs/react.
