### PR TITLE
[material-ui-currency-textfield] Add version 0.8.6

### DIFF
--- a/material-ui-currency-textfield/README.md
+++ b/material-ui-currency-textfield/README.md
@@ -1,0 +1,18 @@
+# cljsjs/material-ui-currency-textfield
+
+[](dependency)
+```clojure
+[cljsjs/material-ui-currency-textfield "0.8.6-0"] ;; latest release
+```
+[](/dependency)
+
+This jar comes with `deps.cljs` as used by the [Foreign Libs][flibs] feature
+of the ClojureScript compiler. After adding the above dependency to your project
+you can require the packaged library like so:
+
+```clojure
+(ns application.core
+  (:require cljsjs.material-ui-currency-textfield))
+```
+
+[flibs]: https://clojurescript.org/reference/packaging-foreign-deps

--- a/material-ui-currency-textfield/boot-cljsjs-checksums.edn
+++ b/material-ui-currency-textfield/boot-cljsjs-checksums.edn
@@ -1,0 +1,4 @@
+{"cljsjs/material-ui-currency-textfield/development/material-ui-currency-textfield.inc.js"
+ "531CCA1D8F59D4433F7133AA9FF91185",
+ "cljsjs/material-ui-currency-textfield/production/material-ui-currency-textfield.min.inc.js"
+ "57B5E2E52C03E6B54E955CB5114DD2AA"}

--- a/material-ui-currency-textfield/build.boot
+++ b/material-ui-currency-textfield/build.boot
@@ -1,0 +1,37 @@
+(set-env!
+  :resource-paths #{"resources"}
+  :dependencies '[[cljsjs/boot-cljsjs "0.10.5" :scope "test"]
+                  [cljsjs/material-ui "4.4.1-0"]
+                  [cljsjs/prop-types  "15.7.2-0"]
+                  [cljsjs/react       "16.8.6-0"]
+                  [cljsjs/react-dom   "16.8.6-0"]])
+
+(require '[cljsjs.boot-cljsjs.packaging :refer :all])
+
+(def +lib-version+ "0.8.6")
+(def +version+ (str +lib-version+ "-0"))
+
+(task-options!
+ pom  {:project     'cljsjs/material-ui-currency-textfield
+       :version     +version+
+       :description "Currency input textfield for react with Material-ui style"
+       :url         "https://unicef.github.io/material-ui-currency-textfield"
+       :scm         {:url "https://github.com/cljsjs/packages"}
+       :license     {"MIT" "http://opensource.org/licenses/MIT"}})
+
+(deftask package []
+  (comp
+    (run-commands :commands [["npm" "install"]
+                             ["npm" "run" "build:dev"]
+                             ["npm" "run" "build:prod"]
+                             ["rm" "-rf" "node_modules" "package-lock.json"]])
+
+    (deps-cljs :name "cljsjs.material-ui-currency-textfield"
+               :requires ["cljsjs.material-ui"
+                          "cljsjs.prop-types"
+                          "cljsjs.react"
+                          "cljsjs.react.dom"])
+
+    (pom)
+    (jar)
+    (validate-checksums)))

--- a/material-ui-currency-textfield/resources/cljsjs/material-ui-currency-textfield/common/material-ui-currency-textfield.ext.js
+++ b/material-ui-currency-textfield/resources/cljsjs/material-ui-currency-textfield/common/material-ui-currency-textfield.ext.js
@@ -1,0 +1,1 @@
+var MaterialUICurrencyTextField

--- a/material-ui-currency-textfield/resources/main.js
+++ b/material-ui-currency-textfield/resources/main.js
@@ -1,0 +1,3 @@
+(function () {
+  window["MaterialUICurrencyTextField"] = require('@unicef/material-ui-currency-textfield').default;
+})();

--- a/material-ui-currency-textfield/resources/package.json
+++ b/material-ui-currency-textfield/resources/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@cljsjs/material-ui-currency-textfield-bundle",
+  "private": true,
+  "scripts": {
+    "build:dev": "webpack --mode development",
+    "build:prod": "webpack --mode production"
+  },
+  "dependencies": {
+    "@unicef/material-ui-currency-textfield": "0.8.6"
+  },
+  "devDependencies": {
+    "webpack": "4.42.1",
+    "webpack-cli": "3.3.11"
+  }
+}

--- a/material-ui-currency-textfield/resources/webpack.config.js
+++ b/material-ui-currency-textfield/resources/webpack.config.js
@@ -1,0 +1,34 @@
+const path = require('path');
+
+module.exports = function(env, argv) {
+  const isDevel = argv.mode === 'development';
+
+  return {
+    entry: {
+      'material-ui-currency-textfield': './main.js'
+    },
+    devtool: 'none',
+    output: {
+      filename: isDevel ? '[name].inc.js' : '[name].min.inc.js',
+      path: path.resolve(__dirname, 'cljsjs/material-ui-currency-textfield', argv.mode),
+    },
+    externals: [
+      function(context, request, callback) {
+        const re = /^@material-ui\/core\/(.*)$/;
+        if (re.test(request)) {
+          const [_, name] = re.exec(request);
+          const external = name === 'styles' ? 'MaterialUIStyles' : `MaterialUI.${name}`;
+          return callback(null, `root ${external}`);
+        }
+        callback();
+      },
+      {
+        'prop-types': 'PropTypes',
+        'react': 'React',
+        'react-dom': 'ReactDOM',
+        '@material-ui/core': 'MaterialUI',
+        '@material-ui/styles': 'MaterialUIStyles'
+      }
+    ]
+  };
+}


### PR DESCRIPTION
Hi there! I've prepared a package for this library:
https://github.com/unicef/material-ui-currency-textfield
It passes the build locally, also works inside the cljs app. Can you please review the PR and merge it if it's ok?

Also one question from me - is it mandatory to package separately [autonumeric](https://github.com/unicef/material-ui-currency-textfield/blob/master/package.json#L78) direct dependency of this library? Currently it is bundled with webpack directly into dev/prod bundles.