### PR TITLE
[snabbdom] fix deps.cljs bad paths

### DIFF
--- a/snabbdom/README.md
+++ b/snabbdom/README.md
@@ -1,7 +1,7 @@
 # cljsjs/snabbdom
 [](dependency)
 ```clojure
-[cljsjs/snabbdom "0.7.4-0"] ;; latest release
+[cljsjs/snabbdom "0.7.4-1"] ;; latest release
 ```
 [](/dependency)
 

--- a/snabbdom/build.boot
+++ b/snabbdom/build.boot
@@ -5,7 +5,7 @@
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
 (def +lib-version+ "0.7.4")
-(def +version+ (str +lib-version+ "-0"))
+(def +version+ (str +lib-version+ "-1"))
 
 (task-options!
  pom  {:project     'cljsjs/snabbdom

--- a/snabbdom/resources/deps.cljs
+++ b/snabbdom/resources/deps.cljs
@@ -4,22 +4,22 @@
                  :global-exports {"snabbdom" "snabbdom"}}
                 {:provides ["snabbdom/modules/attributes"]
                  :file "cljsjs/snabbdom/development/snabbdom-attributes.inc.js"
-                 :file-min "cljsjs/snabbdom/development/snabbdom-attributes.min.inc.js"
+                 :file-min "cljsjs/snabbdom/production/snabbdom-attributes.min.inc.js"
                  :global-exports {"snabbdom/modules/attributes" "snabbdom_attributes"}}
                 {:provides ["snabbdom/modules/class"]
                  :file "cljsjs/snabbdom/development/snabbdom-class.inc.js"
-                 :file-min "cljsjs/snabbdom/development/snabbdom-class.min.inc.js"
+                 :file-min "cljsjs/snabbdom/production/snabbdom-class.min.inc.js"
                  :global-exports {"snabbdom/modules/class" "snabbdom_class"}}
                 {:provides ["snabbdom/modules/eventlisteners"]
                  :file "cljsjs/snabbdom/development/snabbdom-eventlisteners.inc.js"
-                 :file-min "cljsjs/snabbdom/development/snabbdom-eventlisteners.min.inc.js"
+                 :file-min "cljsjs/snabbdom/production/snabbdom-eventlisteners.min.inc.js"
                  :global-exports {"snabbdom/modules/eventlisteners" "snabbdom_eventlisteners"}}
                 {:provides ["snabbdom/modules/props"]
                  :file "cljsjs/snabbdom/development/snabbdom-props.inc.js"
-                 :file-min "cljsjs/snabbdom/development/snabbdom-props.min.inc.js"
+                 :file-min "cljsjs/snabbdom/production/snabbdom-props.min.inc.js"
                  :global-exports {"snabbdom/modules/props" "snabbdom_props"}}
                 {:provides ["snabbdom/modules/style"]
                  :file "cljsjs/snabbdom/development/snabbdom-style.inc.js"
-                 :file-min "cljsjs/snabbdom/development/snabbdom-style.min.inc.js"
+                 :file-min "cljsjs/snabbdom/production/snabbdom-style.min.inc.js"
                  :global-exports {"snabbdom/modules/style" "snabbdom_style"}}]
  :externs ["cljsjs/snabbdom/common/snabbdom.ext.js"]}


### PR DESCRIPTION
Noticed this while testing with shadow-cljs. Tested the corrected version after `boot package install target` locally with shadow-cljs and works.