### PR TITLE
Update google-diff-match-patch, use new upstream

### DIFF
--- a/google-diff-match-patch/build.boot
+++ b/google-diff-match-patch/build.boot
@@ -5,24 +5,27 @@
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
 
-(def +lib-version+ "20121119")
-(def +version+ (str +lib-version+ "-2"))
+(def +lib-version+ "62f2e689f498f9c92dbc588c58750addec9b1654")
+(def +version+ (str +lib-version+ "-0"))
 
 (task-options!
  pom  {:project     'cljsjs/google-diff-match-patch
        :version     +version+
        :description "Diff, Match and Patch Library"
-       :url         "http://code.google.com/p/google-diff-match-patch/"
+       :url         "https://github.com/google/diff-match-patch/"
        :scm         {:url "https://github.com/cljsjs/packages"}
        :license     {"Apache v2" "http://www.apache.org/licenses/LICENSE-2.0"}})
 
 (deftask package []
   (comp
-   (download :url (format "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/google-diff-match-patch/diff_match_patch_%s.zip" +lib-version+)
-             :checksum "c0d22f0c04da5760ecb2c2040daa6703"
+   (download :url (format "https://github.com/google/diff-match-patch/archive/%s.zip"
+                          +lib-version+)
+             :checksum "66a0f0e40ce972eb7e6589ab19328a72"
              :unzip true)
-   (sift :move {#"^diff_match_patch_\d*/javascript/diff_match_patch_uncompressed\.js$" "cljsjs/google-diff-match-patch/development/google-diff-match-patch.inc.js"})
-   (sift :move {#"^diff_match_patch_\d*/javascript/diff_match_patch\.js$" "cljsjs/google-diff-match-patch/production/google-diff-match-patch.min.inc.js"})
+   (sift :move {#"^diff-match-patch-.*?/javascript/diff_match_patch_uncompressed\.js$"
+                "cljsjs/google-diff-match-patch/development/google-diff-match-patch.inc.js"})
+   (sift :move {#"^diff-match-patch-.*?/javascript/diff_match_patch\.js$"
+                "cljsjs/google-diff-match-patch/production/google-diff-match-patch.min.inc.js"})
    (sift :include #{#"^cljsjs"})
    (deps-cljs :name "cljsjs.google-diff-match-patch")
    (pom)


### PR DESCRIPTION
This project seems to have been moved to github:
https://github.com/google/diff-match-patch

It doesn't seem to use any version numbers (or releases), so I've used the git hash as the version (not sure if this is okay). Please let me know if further changes are needed. Thanks!
