### PR TITLE
React-virtualized 9.21.2-1

### DIFF
--- a/react-virtualized/README.md
+++ b/react-virtualized/README.md
@@ -2,7 +2,7 @@
 
 [](dependency)
 ```clojure
-[cljsjs/react-virtualized "9.21.2-0"] ;; latest release
+[cljsjs/react-virtualized "9.21.2-1"] ;; latest release
 ```
 [](/dependency)
 

--- a/react-virtualized/boot-cljsjs-checksums.edn
+++ b/react-virtualized/boot-cljsjs-checksums.edn
@@ -1,4 +1,4 @@
 {"cljsjs/react-virtualized/development/react-virtualized.inc.js"
- "62E3A4DA1B5D74B0D3342ED4E62BED5E",
+ "29B53A5F26645B9E5D617D689E30C4FA",
  "cljsjs/react-virtualized/production/react-virtualized.min.inc.js"
- "068874A7F54C2C6DAA05163C62B33DFB"}
+ "A4B147854835ED5729AA8A88F49D801E"}

--- a/react-virtualized/build.boot
+++ b/react-virtualized/build.boot
@@ -11,7 +11,7 @@
          '[boot.util :refer [sh]])
 
 (def +lib-version+ "9.21.2")
-(def +version+ (str +lib-version+ "-0"))
+(def +version+ (str +lib-version+ "-1"))
 
 (task-options!
  pom  {:project     'cljsjs/react-virtualized

--- a/react-virtualized/resources/cljsjs/react-virtualized/common/react-virtualized.ext.js
+++ b/react-virtualized/resources/cljsjs/react-virtualized/common/react-virtualized.ext.js
@@ -23,7 +23,10 @@ var ReactVirtualized = {
   "CellMeasurer": {
     "__internalCellMeasurerFlag": {}
   },
-  "CellMeasurerCache": function () {},
+  "CellMeasurerCache": {
+    "clear": function () {},
+    "clearAll": function () {}
+  },
   "Collection": {
     "defaultProps": {
       "aria-label": {},
@@ -490,7 +493,10 @@ var ReactVirtualized = {
           "CellMeasurer": {
             "__internalCellMeasurerFlag": {}
           },
-          "CellMeasurerCache": function () {},
+          "CellMeasurerCache": {
+            "clear": function () {},
+            "clearAll": function () {}
+          },
           "Collection": {
             "defaultProps": {
               "aria-label": {},


### PR DESCRIPTION
Updated react-virtualized 9.21.2 externs manually since the automatic script left out at least these 2 functions:

```
ReactVirtualizer.CellMeasurerCache.clear
ReactVirtualizer.CellMeasurerCache.clearAll
```