### PR TITLE
[highcharts] Fix highchart deps.cljs file and file-min options

### DIFF
--- a/highcharts/README.md
+++ b/highcharts/README.md
@@ -2,7 +2,7 @@
 
 [](dependency)
 ```clojure
-[cljsjs/highcharts "7.0.3-1"] ;; latest release
+[cljsjs/highcharts "7.0.3-2"] ;; latest release
 ```
 [](/dependency)
 

--- a/highcharts/build.boot
+++ b/highcharts/build.boot
@@ -5,7 +5,7 @@
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
 (def +lib-version+ "7.0.3")
-(def +version+ (str +lib-version+ "-1"))
+(def +version+ (str +lib-version+ "-2"))
 
 (task-options!
  pom  {:project     'cljsjs/highcharts
@@ -24,10 +24,10 @@
     {:file-min "cljsjs/highcharts/production/highcharts.min.inc.js"
      :file path
      :provides ["cljsjs.highcharts"]}
-    {:file-min path
-     :file (-> path
-               (string/replace #"\.inc\.js$" ".min.inc.js")
-               (string/replace #"/development/" "/production/"))
+    {:file path
+     :file-min (-> path
+                 (string/replace #"\.inc\.js$" ".min.inc.js")
+                 (string/replace #"/development/" "/production/"))
      :requires ["cljsjs.highcharts"]
      :provides [(-> path
                     (string/replace #"\.inc\.js$" "")


### PR DESCRIPTION
Highcharts was generating `deps.cljs` with the `:file` pointing to the
minified file and `:file-min` pointing to the non-minified file. This
commit reverts it to how it should be.

<!--
PR Checklist

Have you read either:
https://github.com/cljsjs/packages/wiki/Creating-Packages
https://github.com/cljsjs/packages/wiki/Updating-packages

Did you follow contribution guidelines:
https://github.com/cljsjs/packages/blob/master/CONTRIBUTING.md

Did you remember to run package script locally and commit
boot-cljsjs-checksum.edn file changes?

boot package install
-->
