### PR TITLE
Fix broken (0-kb) bigfraction.min.inc.js in bigfraction package

### DIFF
--- a/bigfraction/boot-cljsjs-checksums.edn
+++ b/bigfraction/boot-cljsjs-checksums.edn
@@ -1,4 +1,4 @@
 {"cljsjs/fraction/development/bigfraction.inc.js"
- "3500500CDAAB97B7B04F9B9076B94091",
+ "4230A27BC33A197355EAC929EC730C40",
  "cljsjs/fraction/production/bigfraction.min.inc.js"
- "D41D8CD98F00B204E9800998ECF8427E"}
+ "B715F844B4D7EA1E40B16AD9C25AC5D3"}

--- a/bigfraction/build.boot
+++ b/bigfraction/build.boot
@@ -4,7 +4,7 @@
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
-(def +lib-version+ "4.0.12")
+(def +lib-version+ "4.1.1")
 (def +version+ (str +lib-version+ "-0"))
 
 (task-options!
@@ -26,6 +26,56 @@
 (deftask package []
   (comp
    (build-fraction)
+   (replace-content :in "bigfraction.bundle.js"
+                    :out "bigfraction.bundle.js"
+                    :match #"10 \*\* Math.floor\(1 \+ Math.log10\(p1\)\);"
+                    :value "Math.pow(10, Math.floor(1 + Math.log10(p1)));")
+
+   (replace-content :in "bigfraction.bundle.js"
+                    :out "bigfraction.bundle.js"
+                    :match #"C_TEN \*\* BigInt\(match\[ndx\].length\);"
+                    :value "Math.pow(C_TEN, BigInt(match[ndx].length));")
+
+   (replace-content :in "bigfraction.bundle.js"
+                    :out "bigfraction.bundle.js"
+                    :match #"C_TEN \*\* BigInt\(match\[ndx \+ 1\].length\)"
+                    :value "Math.pow(C_TEN, BigInt(match[ndx + 1].length))")
+
+   (replace-content :in "bigfraction.bundle.js"
+                    :out "bigfraction.bundle.js"
+                    :match #"\(this\['s'\] \* this\[\"d\"\]\) \*\* P\['n'\]"
+                    :value "Math.pow((this['s'] * this[\"d\"]), P['n'])")
+
+   (replace-content :in "bigfraction.bundle.js"
+                    :out "bigfraction.bundle.js"
+                    :match #"\(this\['s'\] \* this\[\"n\"\]\) \*\* P\['n'\]"
+                    :value "Math.pow((this['s'] * this[\"n\"]), P['n'])")
+
+   (replace-content :in "bigfraction.bundle.js"
+                    :out "bigfraction.bundle.js"
+                    :match #"this\[\"n\"\] \*\* P\['n'\]"
+                    :value "Math.pow(this[\"n\"], P['n'])")
+
+   (replace-content :in "bigfraction.bundle.js"
+                    :out "bigfraction.bundle.js"
+                    :match #"this\[\"d\"\] \*\* P\['n'\]"
+                    :value "Math.pow(this[\"d\"], P['n'])")
+
+   (replace-content :in "bigfraction.bundle.js"
+                    :out "bigfraction.bundle.js"
+                    :match #"BigInt\(k\) \*\* N\[k\]"
+                    :value "Math.pow(BigInt(k), N[k])")
+
+   (replace-content :in "bigfraction.bundle.js"
+                    :out "bigfraction.bundle.js"
+                    :match #"BigInt\(k\) \*\* D\[k\]"
+                    :value "Math.pow(BigInt(k), D[k])")
+
+   (replace-content :in "bigfraction.bundle.js"
+                    :out "bigfraction.bundle.js"
+                    :match #"10 \*\* Number\(places \|\| 0\)"
+                    :value "Math.pow(10, Number(places || 0))")
+
    (sift :move {#".*bigfraction.bundle.js" "cljsjs/fraction/development/bigfraction.inc.js"
                 #".*bigfraction.ext.js" "cljsjs/fraction/common/bigfraction.ext.js"})
    (minify    :in  "cljsjs/fraction/development/bigfraction.inc.js"


### PR DESCRIPTION
The asset minifier doesn't seem to like inputs of the form `a ** b`, so I replaced each of these with `Math.pow(a, b)` calls.