### PR TITLE
Upgrade bigfraction to 4.1.1

### DIFF
--- a/bigfraction/README.md
+++ b/bigfraction/README.md
@@ -2,7 +2,7 @@
 
 [](dependency)
 ```clojure
-[cljsjs/bigfraction "4.0.12-0"] ;; latest release
+[cljsjs/bigfraction "4.1.1-0"] ;; latest release
 ```
 [](/dependency)
 

--- a/bigfraction/boot-cljsjs-checksums.edn
+++ b/bigfraction/boot-cljsjs-checksums.edn
@@ -1,4 +1,4 @@
 {"cljsjs/fraction/development/bigfraction.inc.js"
- "4230A27BC33A197355EAC929EC730C40",
+ "76CC0F5428DBE041BF3CF80B024FFE9C",
  "cljsjs/fraction/production/bigfraction.min.inc.js"
- "B715F844B4D7EA1E40B16AD9C25AC5D3"}
+ "8BF5181964CF2D08FD01A1B9AA4ED008"}

--- a/bigfraction/boot-cljsjs-checksums.edn
+++ b/bigfraction/boot-cljsjs-checksums.edn
@@ -1,4 +1,4 @@
 {"cljsjs/fraction/development/bigfraction.inc.js"
- "76CC0F5428DBE041BF3CF80B024FFE9C",
+ "4230A27BC33A197355EAC929EC730C40",
  "cljsjs/fraction/production/bigfraction.min.inc.js"
- "8BF5181964CF2D08FD01A1B9AA4ED008"}
+ "B715F844B4D7EA1E40B16AD9C25AC5D3"}

--- a/bigfraction/boot-cljsjs-checksums.edn
+++ b/bigfraction/boot-cljsjs-checksums.edn
@@ -1,4 +1,4 @@
 {"cljsjs/fraction/development/bigfraction.inc.js"
- "3500500CDAAB97B7B04F9B9076B94091",
+ "4230A27BC33A197355EAC929EC730C40",
  "cljsjs/fraction/production/bigfraction.min.inc.js"
- "D41D8CD98F00B204E9800998ECF8427E"}
+ "B715F844B4D7EA1E40B16AD9C25AC5D3"}

--- a/bigfraction/build.boot
+++ b/bigfraction/build.boot
@@ -4,7 +4,7 @@
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
-(def +lib-version+ "4.0.12")
+(def +lib-version+ "4.1.1")
 (def +version+ (str +lib-version+ "-0"))
 
 (task-options!
@@ -26,6 +26,56 @@
 (deftask package []
   (comp
    (build-fraction)
+   (replace-content :in "bigfraction.bundle.js"
+                    :out "bigfraction.bundle.js"
+                    :match #"10 \*\* Math.floor\(1 \+ Math.log10\(p1\)\);"
+                    :value "Math.pow(10, Math.floor(1 + Math.log10(p1)));")
+
+   (replace-content :in "bigfraction.bundle.js"
+                    :out "bigfraction.bundle.js"
+                    :match #"C_TEN \*\* BigInt\(match\[ndx\].length\);"
+                    :value "Math.pow(C_TEN, BigInt(match[ndx].length));")
+
+   (replace-content :in "bigfraction.bundle.js"
+                    :out "bigfraction.bundle.js"
+                    :match #"C_TEN \*\* BigInt\(match\[ndx \+ 1\].length\)"
+                    :value "Math.pow(C_TEN, BigInt(match[ndx + 1].length))")
+
+   (replace-content :in "bigfraction.bundle.js"
+                    :out "bigfraction.bundle.js"
+                    :match #"\(this\['s'\] \* this\[\"d\"\]\) \*\* P\['n'\]"
+                    :value "Math.pow((this['s'] * this[\"d\"]), P['n'])")
+
+   (replace-content :in "bigfraction.bundle.js"
+                    :out "bigfraction.bundle.js"
+                    :match #"\(this\['s'\] \* this\[\"n\"\]\) \*\* P\['n'\]"
+                    :value "Math.pow((this['s'] * this[\"n\"]), P['n'])")
+
+   (replace-content :in "bigfraction.bundle.js"
+                    :out "bigfraction.bundle.js"
+                    :match #"this\[\"n\"\] \*\* P\['n'\]"
+                    :value "Math.pow(this[\"n\"], P['n'])")
+
+   (replace-content :in "bigfraction.bundle.js"
+                    :out "bigfraction.bundle.js"
+                    :match #"this\[\"d\"\] \*\* P\['n'\]"
+                    :value "Math.pow(this[\"d\"], P['n'])")
+
+   (replace-content :in "bigfraction.bundle.js"
+                    :out "bigfraction.bundle.js"
+                    :match #"BigInt\(k\) \*\* N\[k\]"
+                    :value "Math.pow(BigInt(k), N[k])")
+
+   (replace-content :in "bigfraction.bundle.js"
+                    :out "bigfraction.bundle.js"
+                    :match #"BigInt\(k\) \*\* D\[k\]"
+                    :value "Math.pow(BigInt(k), D[k])")
+
+   (replace-content :in "bigfraction.bundle.js"
+                    :out "bigfraction.bundle.js"
+                    :match #"10 \*\* Number\(places \|\| 0\)"
+                    :value "Math.pow(10, Number(places || 0))")
+
    (sift :move {#".*bigfraction.bundle.js" "cljsjs/fraction/development/bigfraction.inc.js"
                 #".*bigfraction.ext.js" "cljsjs/fraction/common/bigfraction.ext.js"})
    (minify    :in  "cljsjs/fraction/development/bigfraction.inc.js"

--- a/bigfraction/build.boot
+++ b/bigfraction/build.boot
@@ -28,6 +28,16 @@
    (build-fraction)
    (replace-content :in "bigfraction.bundle.js"
                     :out "bigfraction.bundle.js"
+                    :match #"Fraction\(\(this\['s'\] \* this\[\"d\"\]\) \*\* BigInt\(-m\), this\[\"n\"\] \*\* BigInt\(-m\)\)"
+                    :value "Fraction(Math.pow((this['s'] * this[\"d\"]), BigInt(-m)), Math.pow(this[\"n\"], BigInt(-m)))")
+
+   (replace-content :in "bigfraction.bundle.js"
+                    :out "bigfraction.bundle.js"
+                    :match #"Fraction\(\(this\['s'\] \* this\[\"n\"\]\) \*\* BigInt\(\+m\), this\[\"d\"\] \*\* BigInt\(\+m\)\)"
+                    :value "Fraction(Math.pow((this['s'] * this[\"n\"]), BigInt(+m)), Math.pow(this[\"d\"], BigInt(+m)))")
+
+   (replace-content :in "bigfraction.bundle.js"
+                    :out "bigfraction.bundle.js"
                     :match #"10 \*\* Math.floor\(1 \+ Math.log10\(p1\)\);"
                     :value "Math.pow(10, Math.floor(1 + Math.log10(p1)));")
 

--- a/bigfraction/build.boot
+++ b/bigfraction/build.boot
@@ -4,8 +4,8 @@
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
-(def +lib-version+ "4.1.1")
-(def +version+ (str +lib-version+ "-0"))
+(def +lib-version+ "4.0.12")
+(def +version+ (str +lib-version+ "-1"))
 
 (task-options!
  push {:ensure-clean false}

--- a/bigfraction/build.boot
+++ b/bigfraction/build.boot
@@ -4,8 +4,8 @@
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
-(def +lib-version+ "4.0.12")
-(def +version+ (str +lib-version+ "-1"))
+(def +lib-version+ "4.1.1")
+(def +version+ (str +lib-version+ "-0"))
 
 (task-options!
  push {:ensure-clean false}

--- a/bigfraction/resources/package.json
+++ b/bigfraction/resources/package.json
@@ -21,7 +21,7 @@
     },
     "license": "MIT OR GPL-2.0-or-later",
     "dependencies": {
-        "fraction.js": "^4.0.12"
+        "fraction.js": "4.0.12"
     },
     "devDependencies": {
         "cross-env": "^3.1.4",

--- a/bigfraction/resources/package.json
+++ b/bigfraction/resources/package.json
@@ -1,7 +1,7 @@
 {
     "name": "fraction.js",
     "title": "fraction.js",
-    "version": "4.0.12",
+    "version": "4.1.1",
     "homepage": "http://www.xarg.org/2014/03/rational-numbers-in-javascript/",
     "bugs": "https://github.com/infusion/Fraction.js/issues",
     "description": "A rational number library",
@@ -21,7 +21,7 @@
     },
     "license": "MIT OR GPL-2.0-or-later",
     "dependencies": {
-        "fraction.js": "4.0.12"
+        "fraction.js": "4.1.1"
     },
     "devDependencies": {
         "cross-env": "^3.1.4",


### PR DESCRIPTION
This PR upgrades the bigfraction package to version 4.1.1.

NOTE: Please merge this after #2190 , so that we can get that bugfix published for the older version. Thank you!