### PR TITLE
[react-share] change react-share project group to io.github.cljsjs

### DIFF
--- a/react-share/build.boot
+++ b/react-share/build.boot
@@ -9,7 +9,7 @@
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
 (task-options!
- pom  {:project     'cljsjs/react-share
+ pom  {:project     'io.github.cljsjs/react-share
        :version     +version+
        :description "A draggable and resizable grid layout with responsive breakpoints, for React."
        :url         "https://github.com/touhonoob/react-share"


### PR DESCRIPTION
update project group of react-share according to 1b387147c258730b7c02544ed341f80adb4ed914