### PR TITLE
[konami] Update upstream library version to 1.6.3

### DIFF
--- a/konami/README.md
+++ b/konami/README.md
@@ -1,8 +1,10 @@
 # cljsjs/konami
 
+A cljsjs package for [konami-js][konamijs] JavaScript library.
+
 [](dependency)
 ```clojure
-[cljsjs/konami "1.6.2-0"] ;; latest release
+[cljsjs/konami "1.6.3-0"] ;; latest release
 ```
 [](/dependency)
 
@@ -10,10 +12,17 @@
 
 This jar comes with `deps.cljs` as used by the [Foreign Libs][flibs] feature
 of the ClojureScript compiler. After adding the above dependency to your project
-you can require the packaged library like so:
+you can require, and use, the packaged library like so:
 
 ```clojure
 (ns application.core
   (:require cljsjs.konami))
+
+(def easter-egg (js/Konami. (fn [] (js/alert "Hello Konami code!"))))
 ```
+
+An example project using the konami package can be seen [here][konamitest].
+
+[konamijs]: https://konamijs.mand.is/
 [flibs]: https://clojurescript.org/reference/packaging-foreign-deps
+[konamitest]: https://github.com/28/konami-cljs-test

--- a/konami/boot-cljsjs-checksums.edn
+++ b/konami/boot-cljsjs-checksums.edn
@@ -1,4 +1,4 @@
 {"cljsjs/konami/development/konami.inc.js"
- "CED3E517BE8EF64F5268336E03E6BF10",
+ "7BC5D4607453CC6D04D26EAA28FAFA64",
  "cljsjs/konami/production/konami.min.inc.js"
  "E5018BD3FBE95C93C84932298747F567"}

--- a/konami/build.boot
+++ b/konami/build.boot
@@ -4,14 +4,14 @@
 
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
-(def +lib-version+ "1.6.2")
+(def +lib-version+ "1.6.3")
 (def +version+ (str +lib-version+ "-0"))
 
 (task-options!
  pom  {:project     'cljsjs/konami
        :version     +version+
        :description "A quick and silly script for adding the Konami Code easter egg to your site."
-       :url         "http://snaptortoise.github.io/konami-js/"
+       :url         "https://konamijs.mand.is/"
        :scm         {:url "https://github.com/cljsjs/packages"}
        :license     {"MIT" "https://opensource.org/licenses/MIT"}})
 


### PR DESCRIPTION
Hi,

This PR updates the upstream library - konami-js- version to 1.6.3 since the author made a release a couple of days ago.
I also took the opportunity to update the README a bit.

Looking at the lib changes there are no API changes, mostly cosmetic (which can be seen from the unchanged minified file checksum).

Cheers.