### PR TITLE
[js-joda] Add missing externs for ToNativeJSConverter

### DIFF
--- a/js-joda/boot-cljsjs-checksums.edn
+++ b/js-joda/boot-cljsjs-checksums.edn
@@ -1,0 +1,2 @@
+{"cljsjs/js-joda-core/js-joda.inc.js"
+ "C958D446BF74BCDF16DAC18456DDA408"}

--- a/js-joda/build.boot
+++ b/js-joda/build.boot
@@ -5,7 +5,7 @@
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
 (def +lib-version+ "1.12.0")
-(def +version+ (str +lib-version+ "-0"))
+(def +version+ (str +lib-version+ "-1"))
 
 (task-options!
  pom  {:project     'cljsjs/js-joda

--- a/js-joda/resources/cljsjs/js-joda/common/js-joda.ext.js
+++ b/js-joda/resources/cljsjs/js-joda/common/js-joda.ext.js
@@ -9406,6 +9406,10 @@ JSJoda._.StringBuilder.prototype = {
   "setLength": function () {},
   "toString": function () {}
 };
+JSJoda.ToNativeJsConverter.prototype = {
+  "toDate": function() {},
+  "toEpochMilli": function() {}
+}
 
 /**********************************************************************
  * End Generated Extern for JSJoda
@@ -9609,3 +9613,4 @@ JSJoda.DateTimeFormatter.parsedLeapSecond
 JSJoda.ResolverStyle
 JSJoda.ResolverStyle.values
 JSJoda.ResolverStyle.valueOf
+JSJoda.ToNativeJsConverter


### PR DESCRIPTION
Adds the ToNativeJSConverter class with its two functions: toDate and toEpochMilli.
Also adds boot checksum to the library.