### PR TITLE
[esri-leaflet] Fix library externs shadowing other L externs

### DIFF
--- a/esri-leaflet/README.md
+++ b/esri-leaflet/README.md
@@ -6,7 +6,7 @@ https://github.com/Esri/esri-leaflet/
 
 [](dependency)
 ```clojure
-[cljsjs/esri-leaflet "3.0.1-0"] ;; latest release
+[cljsjs/esri-leaflet "3.0.1-1"] ;; latest release
 ```
 [](/dependency)
 

--- a/esri-leaflet/build.boot
+++ b/esri-leaflet/build.boot
@@ -6,7 +6,7 @@
 (require '[cljsjs.boot-cljsjs.packaging :refer :all])
 
 (def +lib-version+ "3.0.1")
-(def +version+ (str +lib-version+ "-0"))
+(def +version+ (str +lib-version+ "-1"))
 
 (task-options!
  pom  {:project     'cljsjs/esri-leaflet

--- a/esri-leaflet/resources/cljsjs/esri-leaflet/common/esri-leaflet.ext.js
+++ b/esri-leaflet/resources/cljsjs/esri-leaflet/common/esri-leaflet.ext.js
@@ -1,6 +1,4 @@
-var L = {
-  "esri": function () {}
-};
+L.esri = function () {};
 
 L.esri.prototype = {
   "VERSION": {},


### PR DESCRIPTION
The 'var L' syntax was shadowing/overriding externs declared by other Leaflet libraries. The new syntax just declares 'L.esri' without affecting other 'L.XXX' externs.

<!--
PR Checklist

Have you read either:
https://github.com/cljsjs/packages/wiki/Creating-Packages
https://github.com/cljsjs/packages/wiki/Updating-packages

Did you follow contribution guidelines:
https://github.com/cljsjs/packages/blob/master/CONTRIBUTING.md

Did you remember to run package script locally and commit
boot-cljsjs-checksum.edn file changes?

boot package install
-->
