### PR TITLE
[js-joda-locale-fr-fr] Fix package group name

### DIFF
--- a/js-joda-locale-fr-fr/README.md
+++ b/js-joda-locale-fr-fr/README.md
@@ -2,7 +2,7 @@
 
 [](dependency)
 ```clojure
-[cljsjs/js-joda-locale-fr-fr "3.1.1-1"] ;; latest release
+[io.github.cljsjs/js-joda-locale-fr-fr "3.1.1-1"] ;; latest release
 ```
 [](/dependency)
 

--- a/js-joda-locale-fr-fr/build.boot
+++ b/js-joda-locale-fr-fr/build.boot
@@ -9,7 +9,7 @@
 
 (task-options!
   push {:repo "clojars"}
-  pom  {:project     'cljsjs/js-joda-locale-fr-fr
+  pom  {:project     'io.github.cljsjs/js-joda-locale-fr-fr
         :version     +version+
         :description "prebuilt fr-fr locale addon for js-joda"
         :url         "https://js-joda.github.io/js-joda/js-joda-locale"


### PR DESCRIPTION
The package was created in a previous commit, but it was using the legacy package group-name. Since 2021-04-18 Clojars doesn't support unverified group names [1], so the new 'io.github.cljsjs' group has to be used.

The wrong group-name was making the deployment pipelines fail.

[1]https://github.com/clojars/clojars-web/wiki/Verified-Group-Names

<!--
PR Checklist

Have you read either:
https://github.com/cljsjs/packages/wiki/Creating-Packages
https://github.com/cljsjs/packages/wiki/Updating-packages

Did you follow contribution guidelines:
https://github.com/cljsjs/packages/blob/master/CONTRIBUTING.md

Did you remember to run package script locally and commit
boot-cljsjs-checksum.edn file changes?

boot package install
-->
